### PR TITLE
Comment out fix epoch size `require`

### DIFF
--- a/contracts/child/ChildValidatorSet.sol
+++ b/contracts/child/ChildValidatorSet.sol
@@ -95,7 +95,8 @@ contract ChildValidatorSet is
         uint256 newEpochId = currentEpochId++;
         require(id == newEpochId, "UNEXPECTED_EPOCH_ID");
         require(epoch.endBlock > epoch.startBlock, "NO_BLOCKS_COMMITTED");
-        require((epoch.endBlock - epoch.startBlock + 1) % SPRINT == 0, "EPOCH_MUST_BE_DIVISIBLE_BY_64");
+        // TODO: Implement configurable epoch size
+        // require((epoch.endBlock - epoch.startBlock + 1) % SPRINT == 0, "EPOCH_MUST_BE_DIVISIBLE_BY_64");
         require(epochs[newEpochId - 1].endBlock + 1 == epoch.startBlock, "INVALID_START_BLOCK");
 
         Epoch storage newEpoch = epochs[newEpochId];


### PR DESCRIPTION
This PR comments out `require` which asserts that epochs are exactly 64 blocks long in order to unblock release of Edge client.