### PR TITLE
fix: add native token mapping on root ERC20 predicate

### DIFF
--- a/contracts/root/RootERC20Predicate.sol
+++ b/contracts/root/RootERC20Predicate.sol
@@ -54,7 +54,8 @@ contract RootERC20Predicate is Initializable {
         address newStateSender,
         address newExitHelper,
         address newChildERC20Predicate,
-        address newChildTokenTemplate
+        address newChildTokenTemplate,
+        address nativeTokenRootAddress
     ) external initializer {
         require(
             newStateSender != address(0) &&
@@ -67,6 +68,10 @@ contract RootERC20Predicate is Initializable {
         exitHelper = newExitHelper;
         childERC20Predicate = newChildERC20Predicate;
         childTokenTemplate = newChildTokenTemplate;
+        if (nativeTokenRootAddress != address(0)) {
+            rootTokenToChildToken[nativeTokenRootAddress] = 0x0000000000000000000000000000000000001010;
+            emit TokenMapped(nativeTokenRootAddress, 0x0000000000000000000000000000000000001010);
+        }
     }
 
     /**

--- a/docs/root/RootERC20Predicate.md
+++ b/docs/root/RootERC20Predicate.md
@@ -150,7 +150,7 @@ function exitHelper() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate) external nonpayable
+function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate, address nativeTokenRootAddress) external nonpayable
 ```
 
 Initilization function for RootERC20Predicate
@@ -165,6 +165,7 @@ Initilization function for RootERC20Predicate
 | newExitHelper | address | Address of ExitHelper to receive withdrawal information from |
 | newChildERC20Predicate | address | Address of child ERC20 predicate to communicate with |
 | newChildTokenTemplate | address | undefined |
+| nativeTokenRootAddress | address | undefined |
 
 ### mapToken
 

--- a/test/root/RootERC20Predicate.test.ts
+++ b/test/root/RootERC20Predicate.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { ethers, network } from "hardhat";
+import { ethers } from "hardhat";
 import {
   RootERC20Predicate,
   RootERC20Predicate__factory,
@@ -11,12 +11,10 @@ import {
   ChildERC20__factory,
   MockERC20,
 } from "../../typechain-types";
-import { setCode, setBalance, impersonateAccount } from "@nomicfoundation/hardhat-network-helpers";
+import { setBalance, impersonateAccount } from "@nomicfoundation/hardhat-network-helpers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { smock } from "@defi-wonderland/smock";
-import { alwaysTrueBytecode } from "../constants";
 
-describe("ChildERC20Predicate", () => {
+describe("RootERC20Predicate", () => {
   let rootERC20Predicate: RootERC20Predicate,
     exitHelperRootERC20Predicate: RootERC20Predicate,
     stateSender: StateSender,
@@ -62,28 +60,35 @@ describe("ChildERC20Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootERC20Predicate: BAD_INITIALIZATION");
   });
 
   it("initialize and validate initialization", async () => {
+    const nativeTokenRootAddress = ethers.Wallet.createRandom().address;
     await rootERC20Predicate.initialize(
       stateSender.address,
       exitHelper.address,
       childERC20Predicate,
-      childTokenTemplate.address
+      childTokenTemplate.address,
+      nativeTokenRootAddress
     );
 
     expect(await rootERC20Predicate.stateSender()).to.equal(stateSender.address);
     expect(await rootERC20Predicate.exitHelper()).to.equal(exitHelper.address);
     expect(await rootERC20Predicate.childERC20Predicate()).to.equal(childERC20Predicate);
     expect(await rootERC20Predicate.childTokenTemplate()).to.equal(childTokenTemplate.address);
+    expect(await rootERC20Predicate.rootTokenToChildToken(nativeTokenRootAddress)).to.equal(
+      "0x0000000000000000000000000000000000001010"
+    );
   });
 
   it("fail reinitialization", async () => {
     await expect(
       rootERC20Predicate.initialize(
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
Fixes a problem where a native token that needs to be mapped does not exist on the root predicate.