### PR TITLE
Improve `bridge_generateExitProof` JSON RPC endpoint UX

### DIFF
--- a/contracts/interfaces/ICheckpointManager.sol
+++ b/contracts/interfaces/ICheckpointManager.sol
@@ -72,17 +72,17 @@ interface ICheckpointManager {
     ) external view returns (bool);
 
     /**
+     * @notice Function to get the checkpoint block number for a block number.
+     * It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.
+     * @param blockNumber The block number to get the checkpoint block number for
+     * @return bool If block number was checkpointed
+     * @return uint256 The checkpoint block number
+     */
+    function getCheckpointBlock(uint256 blockNumber) external view returns (bool, uint256);
+
+    /**
      * @notice Function to get the event root for a block number
      * @param blockNumber The block number to get the event root for
      */
     function getEventRootByBlock(uint256 blockNumber) external view returns (bytes32);
-
-    /**
-     * @notice Function to get the checkpoint block number for a block number.
-     * It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.
-     * @param blockNumber The block number to get the checkpoint block number for
-     * @return The checkpoint block number
-     * @return The indicator if checkpoint block number was sucessfully resolved
-     */
-    function findCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool);
 }

--- a/contracts/interfaces/ICheckpointManager.sol
+++ b/contracts/interfaces/ICheckpointManager.sol
@@ -76,4 +76,13 @@ interface ICheckpointManager {
      * @param blockNumber The block number to get the event root for
      */
     function getEventRootByBlock(uint256 blockNumber) external view returns (bytes32);
+
+    /**
+     * @notice Function to get the checkpoint block number for a block number.
+     * It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.
+     * @param blockNumber The block number to get the checkpoint block number for
+     * @return The checkpoint block number
+     * @return The indicator if checkpoint block number was sucessfully resolved
+     */
+    function getCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool);
 }

--- a/contracts/interfaces/ICheckpointManager.sol
+++ b/contracts/interfaces/ICheckpointManager.sol
@@ -84,5 +84,5 @@ interface ICheckpointManager {
      * @return The checkpoint block number
      * @return The indicator if checkpoint block number was sucessfully resolved
      */
-    function getCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool);
+    function findCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool);
 }

--- a/contracts/root/CheckpointManager.sol
+++ b/contracts/root/CheckpointManager.sol
@@ -125,22 +125,19 @@ contract CheckpointManager is ICheckpointManager, Initializable {
     /**
      * @inheritdoc ICheckpointManager
      */
-    function getEventRootByBlock(uint256 blockNumber) public view returns (bytes32) {
-        return checkpoints[checkpointBlockNumbers.findUpperBound(blockNumber) + 1].eventRoot;
+    function getCheckpointBlock(uint256 blockNumber) external view returns (bool, uint256) {
+        uint256 checkpointBlockIdx = checkpointBlockNumbers.findUpperBound(blockNumber);
+        if (checkpointBlockIdx == checkpointBlockNumbers.length) {
+            return (false, 0);
+        }
+        return (true, checkpointBlockNumbers[checkpointBlockIdx]);
     }
 
     /**
      * @inheritdoc ICheckpointManager
      */
-    function findCheckpointBlock(uint256 blockNumber) public view returns (uint256, bool) {
-        if (checkpointBlockNumbers.length == 0) {
-            return (0, false);
-        }
-        uint256 checkpointBlockIdx = checkpointBlockNumbers.findUpperBound(blockNumber);
-        if (checkpointBlockIdx > checkpointBlockNumbers.length - 1) {
-            return (0, false);
-        }
-        return (checkpointBlockNumbers[checkpointBlockIdx], true);
+    function getEventRootByBlock(uint256 blockNumber) public view returns (bytes32) {
+        return checkpoints[checkpointBlockNumbers.findUpperBound(blockNumber) + 1].eventRoot;
     }
 
     function _setNewValidatorSet(Validator[] calldata newValidatorSet) private {

--- a/contracts/root/CheckpointManager.sol
+++ b/contracts/root/CheckpointManager.sol
@@ -140,11 +140,7 @@ contract CheckpointManager is ICheckpointManager, Initializable {
         if (checkpointBlockIdx > checkpointBlockNumbers.length - 1) {
             return (0, false);
         }
-        uint256 checkpointBlock = checkpointBlockNumbers[checkpointBlockIdx];
-        if (blockNumber > checkpointBlock) {
-            return (0, false);
-        }
-        return (checkpointBlock, true);
+        return (checkpointBlockNumbers[checkpointBlockIdx], true);
     }
 
     function _setNewValidatorSet(Validator[] calldata newValidatorSet) private {

--- a/contracts/root/CheckpointManager.sol
+++ b/contracts/root/CheckpointManager.sol
@@ -132,7 +132,7 @@ contract CheckpointManager is ICheckpointManager, Initializable {
     /**
      * @inheritdoc ICheckpointManager
      */
-    function getCheckpointBlock(uint256 blockNumber) public view returns (uint256, bool) {
+    function findCheckpointBlock(uint256 blockNumber) public view returns (uint256, bool) {
         if (checkpointBlockNumbers.length == 0) {
             return (0, false);
         }

--- a/contracts/root/CheckpointManager.sol
+++ b/contracts/root/CheckpointManager.sol
@@ -129,6 +129,24 @@ contract CheckpointManager is ICheckpointManager, Initializable {
         return checkpoints[checkpointBlockNumbers.findUpperBound(blockNumber) + 1].eventRoot;
     }
 
+    /**
+     * @inheritdoc ICheckpointManager
+     */
+    function getCheckpointBlock(uint256 blockNumber) public view returns (uint256, bool) {
+        if (checkpointBlockNumbers.length == 0) {
+            return (0, false);
+        }
+        uint256 checkpointBlockIdx = checkpointBlockNumbers.findUpperBound(blockNumber);
+        if (checkpointBlockIdx > checkpointBlockNumbers.length - 1) {
+            return (0, false);
+        }
+        uint256 checkpointBlock = checkpointBlockNumbers[checkpointBlockIdx];
+        if (blockNumber > checkpointBlock) {
+            return (0, false);
+        }
+        return (checkpointBlock, true);
+    }
+
     function _setNewValidatorSet(Validator[] calldata newValidatorSet) private {
         uint256 length = newValidatorSet.length;
         currentValidatorSetLength = length;

--- a/docs/interfaces/ICheckpointManager.md
+++ b/docs/interfaces/ICheckpointManager.md
@@ -10,10 +10,10 @@ Checkpoint manager contract used by validators to submit signed checkpoints as p
 
 ## Methods
 
-### findCheckpointBlock
+### getCheckpointBlock
 
 ```solidity
-function findCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
+function getCheckpointBlock(uint256 blockNumber) external view returns (bool, uint256)
 ```
 
 Function to get the checkpoint block number for a block number. It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.
@@ -30,8 +30,8 @@ Function to get the checkpoint block number for a block number. It finds block n
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The checkpoint block number |
-| _1 | bool | The indicator if checkpoint block number was sucessfully resolved |
+| _0 | bool | bool If block number was checkpointed |
+| _1 | uint256 | uint256 The checkpoint block number |
 
 ### getEventMembershipByBlockNumber
 

--- a/docs/interfaces/ICheckpointManager.md
+++ b/docs/interfaces/ICheckpointManager.md
@@ -10,10 +10,10 @@ Checkpoint manager contract used by validators to submit signed checkpoints as p
 
 ## Methods
 
-### getCheckpointBlock
+### findCheckpointBlock
 
 ```solidity
-function getCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
+function findCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
 ```
 
 Function to get the checkpoint block number for a block number. It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.

--- a/docs/interfaces/ICheckpointManager.md
+++ b/docs/interfaces/ICheckpointManager.md
@@ -10,6 +10,29 @@ Checkpoint manager contract used by validators to submit signed checkpoints as p
 
 ## Methods
 
+### getCheckpointBlock
+
+```solidity
+function getCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
+```
+
+Function to get the checkpoint block number for a block number. It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| blockNumber | uint256 | The block number to get the checkpoint block number for |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | The checkpoint block number |
+| _1 | bool | The indicator if checkpoint block number was sucessfully resolved |
+
 ### getEventMembershipByBlockNumber
 
 ```solidity

--- a/docs/root/CheckpointManager.md
+++ b/docs/root/CheckpointManager.md
@@ -215,10 +215,10 @@ function currentValidatorSetLength() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### getCheckpointBlock
+### findCheckpointBlock
 
 ```solidity
-function getCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
+function findCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
 ```
 
 Function to get the checkpoint block number for a block number. It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.

--- a/docs/root/CheckpointManager.md
+++ b/docs/root/CheckpointManager.md
@@ -215,6 +215,29 @@ function currentValidatorSetLength() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### getCheckpointBlock
+
+```solidity
+function getCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
+```
+
+Function to get the checkpoint block number for a block number. It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| blockNumber | uint256 | The block number to get the checkpoint block number for |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | The checkpoint block number |
+| _1 | bool | The indicator if checkpoint block number was sucessfully resolved |
+
 ### getEventMembershipByBlockNumber
 
 ```solidity

--- a/docs/root/CheckpointManager.md
+++ b/docs/root/CheckpointManager.md
@@ -215,10 +215,10 @@ function currentValidatorSetLength() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### findCheckpointBlock
+### getCheckpointBlock
 
 ```solidity
-function findCheckpointBlock(uint256 blockNumber) external view returns (uint256, bool)
+function getCheckpointBlock(uint256 blockNumber) external view returns (bool, uint256)
 ```
 
 Function to get the checkpoint block number for a block number. It finds block number which is greater or equal than provided one in checkpointBlockNumbers array.
@@ -235,8 +235,8 @@ Function to get the checkpoint block number for a block number. It finds block n
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The checkpoint block number |
-| _1 | bool | The indicator if checkpoint block number was sucessfully resolved |
+| _0 | bool | bool If block number was checkpointed |
+| _1 | uint256 | uint256 The checkpoint block number |
 
 ### getEventMembershipByBlockNumber
 

--- a/test/forge/root/CheckpointManager.t.sol
+++ b/test/forge/root/CheckpointManager.t.sol
@@ -315,20 +315,20 @@ contract CheckpointManager_SubmitSecond is FirstSubmitted {
         checkpointManager.getEventMembershipByEpoch(epoch, leaf, leafIndex, proof);
     }
 
-    function testFindCheckpointBlock_BlockNumberIsCheckpointBlock() public {
+    function testGetCheckpointBlock_BlockNumberIsCheckpointBlock() public {
         uint256 expectedCheckpointBlock = 1;
         uint256 blockNumber = 1;
 
-        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.findCheckpointBlock(blockNumber);
+        (bool isFound, uint256 foundCheckpointBlock) = checkpointManager.getCheckpointBlock(blockNumber);
         assertEq(foundCheckpointBlock, expectedCheckpointBlock);
         assertEq(isFound, true);
     }
 
-    function testFindCheckpointBlock_NonExistingCheckpointBlock() public {
+    function testGetCheckpointBlock_NonExistingCheckpointBlock() public {
         uint256 expectedCheckpointBlock = 0;
         uint256 blockNumber = 5;
 
-        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.findCheckpointBlock(blockNumber);
+        (bool isFound, uint256 foundCheckpointBlock) = checkpointManager.getCheckpointBlock(blockNumber);
         assertEq(foundCheckpointBlock, expectedCheckpointBlock);
         assertEq(isFound, false);
     }

--- a/test/forge/root/CheckpointManager.t.sol
+++ b/test/forge/root/CheckpointManager.t.sol
@@ -314,4 +314,22 @@ contract CheckpointManager_SubmitSecond is FirstSubmitted {
         vm.expectRevert("NO_EVENT_ROOT_FOR_EPOCH");
         checkpointManager.getEventMembershipByEpoch(epoch, leaf, leafIndex, proof);
     }
+
+    function testGetCheckpointBlock_BlockNumberIsCheckpointBlock() public {
+        uint256 expectedCheckpointBlock = 1;
+        uint256 blockNumber = 1;
+
+        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.getCheckpointBlock(blockNumber);
+        assertEq(foundCheckpointBlock, expectedCheckpointBlock);
+        assertEq(isFound, true);
+    }
+
+    function testGetCheckpointBlock_NonExistingCheckpointBlock() public {
+        uint256 expectedCheckpointBlock = 0;
+        uint256 blockNumber = 5;
+
+        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.getCheckpointBlock(blockNumber);
+        assertEq(foundCheckpointBlock, expectedCheckpointBlock);
+        assertEq(isFound, false);
+    }
 }

--- a/test/forge/root/CheckpointManager.t.sol
+++ b/test/forge/root/CheckpointManager.t.sol
@@ -315,20 +315,20 @@ contract CheckpointManager_SubmitSecond is FirstSubmitted {
         checkpointManager.getEventMembershipByEpoch(epoch, leaf, leafIndex, proof);
     }
 
-    function testGetCheckpointBlock_BlockNumberIsCheckpointBlock() public {
+    function testFindCheckpointBlock_BlockNumberIsCheckpointBlock() public {
         uint256 expectedCheckpointBlock = 1;
         uint256 blockNumber = 1;
 
-        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.getCheckpointBlock(blockNumber);
+        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.findCheckpointBlock(blockNumber);
         assertEq(foundCheckpointBlock, expectedCheckpointBlock);
         assertEq(isFound, true);
     }
 
-    function testGetCheckpointBlock_NonExistingCheckpointBlock() public {
+    function testFindCheckpointBlock_NonExistingCheckpointBlock() public {
         uint256 expectedCheckpointBlock = 0;
         uint256 blockNumber = 5;
 
-        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.getCheckpointBlock(blockNumber);
+        (uint256 foundCheckpointBlock, bool isFound) = checkpointManager.findCheckpointBlock(blockNumber);
         assertEq(foundCheckpointBlock, expectedCheckpointBlock);
         assertEq(isFound, false);
     }

--- a/test/root/CheckpointManager.test.ts
+++ b/test/root/CheckpointManager.test.ts
@@ -430,6 +430,8 @@ describe("CheckpointManager", () => {
 
     expect(await checkpointManager.getEventRootByBlock(checkpoint.blockNumber)).to.equal(checkpoint.eventRoot);
     expect(await checkpointManager.checkpointBlockNumbers(0)).to.equal(checkpoint.blockNumber);
+    expect(await checkpointManager.getCheckpointBlock(1)).to.deep.equal([true, checkpoint.blockNumber]);
+    expect(await checkpointManager.getCheckpointBlock(checkpoint.blockNumber + 1)).to.deep.equal([false, 0]);
 
     const leafIndex = 0;
     let proof = [];
@@ -652,6 +654,8 @@ describe("CheckpointManager", () => {
 
     expect(await checkpointManager.getEventRootByBlock(checkpoint.blockNumber)).to.equal(checkpoint.eventRoot);
     expect(await checkpointManager.checkpointBlockNumbers(0)).to.equal(checkpoint.blockNumber);
+    expect(await checkpointManager.getCheckpointBlock(1)).to.deep.equal([true, checkpoint.blockNumber]);
+    expect(await checkpointManager.getCheckpointBlock(checkpoint.blockNumber + 1)).to.deep.equal([false, 0]);
 
     const leafIndex = 0;
     let proof = [];
@@ -731,6 +735,11 @@ describe("CheckpointManager", () => {
 
       expect(await checkpointManager.getEventRootByBlock(checkpoint.blockNumber)).to.equal(checkpoint.eventRoot);
       expect(await checkpointManager.checkpointBlockNumbers(1)).to.equal(checkpoint.blockNumber);
+      expect(await checkpointManager.getCheckpointBlock(checkpoint.blockNumber)).to.deep.equal([
+        true,
+        checkpoint.blockNumber,
+      ]);
+      expect(await checkpointManager.getCheckpointBlock(checkpoint.blockNumber + 1)).to.deep.equal([false, 0]);
 
       const leafIndex = 0;
       let proof = [];


### PR DESCRIPTION
An important part of the assets withdrawal process from the child to the root chain is retrieving an exit proof and submitting it to the `ExitHelper`, as evidence that a given exit event has happened in the first place.

In order for an end-user to be able to retrieve an exit proof, Edge client implemented `bridge_generateExitProof`. However mentioned function expects `exitEventId`, `epochNumber`, and `checkpointBlockNumber` as the input parameters. The downside of this approach is that an end-user must be aware of which checkpoint block his exit event got submitted to the root chain. Unfortunately, this makes UX poor, as an end-user cannot be completely sure which checkpoint block contains his exit event.

Therefore, this PR proposes the introduction of a new function on `CheckpointManager` contract, called `findCheckpointBlock`. This function expects the block number to which the exit event was included on the child chain (this information can be obtained from the receipt, once the transaction is executed on the child chain) and it searches for the next higher `checkpointBlock`.
