### PR TITLE
Remove non-applicable parameter from `RootERC1155Predicate`

### DIFF
--- a/contracts/root/RootERC1155Predicate.sol
+++ b/contracts/root/RootERC1155Predicate.sol
@@ -32,8 +32,7 @@ contract RootERC1155Predicate is IRootERC1155Predicate, IL2StateReceiver, Initia
         address newStateSender,
         address newExitHelper,
         address newChildERC1155Predicate,
-        address newChildTokenTemplate,
-        address nativeTokenRootAddress
+        address newChildTokenTemplate
     ) external initializer {
         require(
             newStateSender != address(0) &&
@@ -46,10 +45,6 @@ contract RootERC1155Predicate is IRootERC1155Predicate, IL2StateReceiver, Initia
         exitHelper = newExitHelper;
         childERC1155Predicate = newChildERC1155Predicate;
         childTokenTemplate = newChildTokenTemplate;
-        if (nativeTokenRootAddress != address(0)) {
-            rootTokenToChildToken[nativeTokenRootAddress] = 0x0000000000000000000000000000000000001010;
-            emit TokenMapped(nativeTokenRootAddress, 0x0000000000000000000000000000000000001010);
-        }
     }
 
     /**

--- a/docs/root/RootERC1155Predicate.md
+++ b/docs/root/RootERC1155Predicate.md
@@ -205,7 +205,7 @@ function exitHelper() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(address newStateSender, address newExitHelper, address newChildERC1155Predicate, address newChildTokenTemplate, address nativeTokenRootAddress) external nonpayable
+function initialize(address newStateSender, address newExitHelper, address newChildERC1155Predicate, address newChildTokenTemplate) external nonpayable
 ```
 
 Initilization function for RootERC1155Predicate
@@ -220,7 +220,6 @@ Initilization function for RootERC1155Predicate
 | newExitHelper | address | Address of ExitHelper to receive withdrawal information from |
 | newChildERC1155Predicate | address | Address of child ERC1155 predicate to communicate with |
 | newChildTokenTemplate | address | undefined |
-| nativeTokenRootAddress | address | undefined |
 
 ### mapToken
 

--- a/test/root/RootERC1155Predicate.test.ts
+++ b/test/root/RootERC1155Predicate.test.ts
@@ -61,35 +61,28 @@ describe("RootERC1155Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
-        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootERC1155Predicate: BAD_INITIALIZATION");
   });
 
   it("initialize and validate initialization", async () => {
-    const nativeTokenRootAddress = ethers.Wallet.createRandom().address;
     await rootERC1155Predicate.initialize(
       stateSender.address,
       exitHelper.address,
       childERC1155Predicate,
-      childTokenTemplate.address,
-      nativeTokenRootAddress
+      childTokenTemplate.address
     );
 
     expect(await rootERC1155Predicate.stateSender()).to.equal(stateSender.address);
     expect(await rootERC1155Predicate.exitHelper()).to.equal(exitHelper.address);
     expect(await rootERC1155Predicate.childERC1155Predicate()).to.equal(childERC1155Predicate);
     expect(await rootERC1155Predicate.childTokenTemplate()).to.equal(childTokenTemplate.address);
-    expect(await rootERC1155Predicate.rootTokenToChildToken(nativeTokenRootAddress)).to.equal(
-      "0x0000000000000000000000000000000000001010"
-    );
   });
 
   it("fail reinitialization", async () => {
     await expect(
       rootERC1155Predicate.initialize(
-        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
`RootERC1155Predicate` has `nativeTokenRootAddress` parameter exposed in initializer, however since it represents ERC 20 token type, it is not applicable for ERC 1155 and therefore it needs to be removed.