### PR TITLE
Provide correct parameters to ERC 1155 bridge actions

### DIFF
--- a/contracts/child/ChildERC1155.sol
+++ b/contracts/child/ChildERC1155.sol
@@ -25,12 +25,12 @@ contract ChildERC1155 is EIP712MetaTransaction, ERC1155Upgradeable, IChildERC115
     /**
      * @inheritdoc IChildERC1155
      */
-    function initialize(address rootToken_, string calldata name_, string calldata uri_) external initializer {
+    function initialize(address rootToken_, string calldata uri_) external initializer {
         require(rootToken_ != address(0), "ChildERC1155: BAD_INITIALIZATION");
         _rootToken = rootToken_;
         _predicate = msg.sender;
         __ERC1155_init(uri_);
-        _initializeEIP712(name_, "1");
+        _initializeEIP712(uri_, "1");
     }
 
     /**

--- a/contracts/child/ChildERC1155Predicate.sol
+++ b/contracts/child/ChildERC1155Predicate.sol
@@ -197,7 +197,7 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Initializable, System 
 
         l2StateSender.syncState(
             rootERC1155Predicate,
-            abi.encode(WITHDRAW_BATCH_SIG, rootToken, msg.sender, receivers, tokenIds)
+            abi.encode(WITHDRAW_BATCH_SIG, rootToken, msg.sender, receivers, tokenIds, amounts)
         );
         // slither-disable-next-line reentrancy-events
         emit L2ERC1155WithdrawBatch(rootToken, address(childToken), msg.sender, receivers, tokenIds, amounts);

--- a/contracts/child/ChildERC1155Predicate.sol
+++ b/contracts/child/ChildERC1155Predicate.sol
@@ -263,17 +263,14 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Initializable, System 
      * @dev Allows for 1-to-1 mappings for any root token to a child token
      */
     function _mapToken(bytes calldata data) private {
-        (, address rootToken, string memory name_, string memory uri_) = abi.decode(
-            data,
-            (bytes32, address, string, string)
-        );
+        (, address rootToken, string memory uri_) = abi.decode(data, (bytes32, address, string));
         assert(rootToken != address(0)); // invariant since root predicate performs the same check
         assert(rootTokenToChildToken[rootToken] == address(0)); // invariant since root predicate performs the same check
         IChildERC1155 childToken = IChildERC1155(
             Clones.cloneDeterministic(childTokenTemplate, keccak256(abi.encodePacked(rootToken)))
         );
         rootTokenToChildToken[rootToken] = address(childToken);
-        childToken.initialize(rootToken, name_, uri_);
+        childToken.initialize(rootToken, uri_);
 
         // slither-disable-next-line reentrancy-events
         emit L2TokenMapped(rootToken, address(childToken));

--- a/contracts/interfaces/IChildERC1155.sol
+++ b/contracts/interfaces/IChildERC1155.sol
@@ -15,7 +15,7 @@ interface IChildERC1155 is IERC1155MetadataURIUpgradeable {
      * This value is immutable: it can only be set once during
      * initialization.
      */
-    function initialize(address rootToken_, string calldata name_, string calldata uri_) external;
+    function initialize(address rootToken_, string calldata uri_) external;
 
     /**
      * @notice Returns predicate address controlling the child token

--- a/contracts/root/RootERC1155Predicate.sol
+++ b/contracts/root/RootERC1155Predicate.sol
@@ -110,7 +110,7 @@ contract RootERC1155Predicate is IRootERC1155Predicate, IL2StateReceiver, Initia
 
         rootTokenToChildToken[address(rootToken)] = childToken;
 
-        stateSender.syncState(childERC1155Predicate, abi.encode(MAP_TOKEN_SIG, rootToken));
+        stateSender.syncState(childERC1155Predicate, abi.encode(MAP_TOKEN_SIG, rootToken, "", rootToken.uri(1)));
         // slither-disable-next-line reentrancy-events
         emit TokenMapped(address(rootToken), childToken);
     }
@@ -187,7 +187,7 @@ contract RootERC1155Predicate is IRootERC1155Predicate, IL2StateReceiver, Initia
 
     function _getChildToken(IERC1155MetadataURI rootToken) private returns (address childToken) {
         childToken = rootTokenToChildToken[address(rootToken)];
-        if (childToken == address(0)) childToken = mapToken(IERC1155MetadataURI(rootToken));
+        if (childToken == address(0)) childToken = mapToken(rootToken);
         assert(childToken != address(0)); // invariant because we map the token if mapping does not exist
     }
 }

--- a/contracts/root/RootERC1155Predicate.sol
+++ b/contracts/root/RootERC1155Predicate.sol
@@ -110,7 +110,7 @@ contract RootERC1155Predicate is IRootERC1155Predicate, IL2StateReceiver, Initia
 
         rootTokenToChildToken[address(rootToken)] = childToken;
 
-        stateSender.syncState(childERC1155Predicate, abi.encode(MAP_TOKEN_SIG, rootToken, "", rootToken.uri(1)));
+        stateSender.syncState(childERC1155Predicate, abi.encode(MAP_TOKEN_SIG, rootToken, rootToken.uri(0)));
         // slither-disable-next-line reentrancy-events
         emit TokenMapped(address(rootToken), childToken);
     }

--- a/docs/child/ChildERC1155.md
+++ b/docs/child/ChildERC1155.md
@@ -155,7 +155,7 @@ function getNonce(address user) external view returns (uint256 nonce)
 ### initialize
 
 ```solidity
-function initialize(address rootToken_, string name_, string uri_) external nonpayable
+function initialize(address rootToken_, string uri_) external nonpayable
 ```
 
 
@@ -167,7 +167,6 @@ function initialize(address rootToken_, string name_, string uri_) external nonp
 | Name | Type | Description |
 |---|---|---|
 | rootToken_ | address | undefined |
-| name_ | string | undefined |
 | uri_ | string | undefined |
 
 ### isApprovedForAll

--- a/docs/elin/contracts/token/ERC1155/extensions/ERC1155Pausable.md
+++ b/docs/elin/contracts/token/ERC1155/extensions/ERC1155Pausable.md
@@ -6,7 +6,7 @@
 
 
 
-*ERC1155 token with pausable token transfers, minting and burning. Useful for scenarios such as preventing trades until the end of an evaluation period, or having an emergency switch for freezing all token transfers in the event of a large bug. IMPORTANT: This contract does not include public pause and unpause functions. In addition to inheriting this contract, you must define both functions, invoking the {Pausable-_pause} and {Pausable-_unpause} internal functions, with appropriate access control, e.g. using {AccessControl} or {Ownable}. Not doing so will make the contract unpausable. _Available since v3.1._*
+*ERC1155 token with pausable token transfers, minting and burning. Useful for scenarios such as preventing trades until the end of an evaluation period, or having an emergency switch for freezing all token transfers in the event of a large bug. _Available since v3.1._*
 
 ## Methods
 

--- a/docs/elin/contracts/token/ERC20/extensions/ERC20Pausable.md
+++ b/docs/elin/contracts/token/ERC20/extensions/ERC20Pausable.md
@@ -6,7 +6,7 @@
 
 
 
-*ERC20 token with pausable token transfers, minting and burning. Useful for scenarios such as preventing trades until the end of an evaluation period, or having an emergency switch for freezing all token transfers in the event of a large bug. IMPORTANT: This contract does not include public pause and unpause functions. In addition to inheriting this contract, you must define both functions, invoking the {Pausable-_pause} and {Pausable-_unpause} internal functions, with appropriate access control, e.g. using {AccessControl} or {Ownable}. Not doing so will make the contract unpausable.*
+*ERC20 token with pausable token transfers, minting and burning. Useful for scenarios such as preventing trades until the end of an evaluation period, or having an emergency switch for freezing all token transfers in the event of a large bug.*
 
 ## Methods
 

--- a/docs/elin/contracts/token/ERC721/extensions/ERC721Pausable.md
+++ b/docs/elin/contracts/token/ERC721/extensions/ERC721Pausable.md
@@ -6,7 +6,7 @@
 
 
 
-*ERC721 token with pausable token transfers, minting and burning. Useful for scenarios such as preventing trades until the end of an evaluation period, or having an emergency switch for freezing all token transfers in the event of a large bug. IMPORTANT: This contract does not include public pause and unpause functions. In addition to inheriting this contract, you must define both functions, invoking the {Pausable-_pause} and {Pausable-_unpause} internal functions, with appropriate access control, e.g. using {AccessControl} or {Ownable}. Not doing so will make the contract unpausable.*
+*ERC721 token with pausable token transfers, minting and burning. Useful for scenarios such as preventing trades until the end of an evaluation period, or having an emergency switch for freezing all token transfers in the event of a large bug.*
 
 ## Methods
 

--- a/docs/interfaces/IChildERC1155.md
+++ b/docs/interfaces/IChildERC1155.md
@@ -107,7 +107,7 @@ Burns multiple NFTs from one address
 ### initialize
 
 ```solidity
-function initialize(address rootToken_, string name_, string uri_) external nonpayable
+function initialize(address rootToken_, string uri_) external nonpayable
 ```
 
 
@@ -119,7 +119,6 @@ function initialize(address rootToken_, string name_, string uri_) external nonp
 | Name | Type | Description |
 |---|---|---|
 | rootToken_ | address | undefined |
-| name_ | string | undefined |
 | uri_ | string | undefined |
 
 ### isApprovedForAll

--- a/test/child/ChildERC1155.test.ts
+++ b/test/child/ChildERC1155.test.ts
@@ -37,7 +37,7 @@ describe("ChildERC1155", () => {
   });
 
   it("fail initialization", async () => {
-    await expect(childERC1155.initialize(ethers.constants.AddressZero, "", "")).to.be.revertedWith(
+    await expect(childERC1155.initialize(ethers.constants.AddressZero, "")).to.be.revertedWith(
       "ChildERC1155: BAD_INITIALIZATION"
     );
   });
@@ -47,14 +47,14 @@ describe("ChildERC1155", () => {
     expect(await childERC1155.predicate()).to.equal(ethers.constants.AddressZero);
 
     predicateChildERC1155 = childERC1155.connect(await ethers.getSigner(childERC1155Predicate.address));
-    await predicateChildERC1155.initialize(rootToken, "TEST", "TEST");
+    await predicateChildERC1155.initialize(rootToken, "TEST");
 
     expect(await childERC1155.rootToken()).to.equal(rootToken);
     expect(await childERC1155.predicate()).to.equal(childERC1155Predicate.address);
   });
 
   it("fail reinitialization", async () => {
-    await expect(childERC1155.initialize(ethers.constants.AddressZero, "", "")).to.be.revertedWith(
+    await expect(childERC1155.initialize(ethers.constants.AddressZero, "")).to.be.revertedWith(
       "Initializable: contract is already initialized"
     );
   });

--- a/test/child/ChildERC1155Predicate.test.ts
+++ b/test/child/ChildERC1155Predicate.test.ts
@@ -406,7 +406,7 @@ describe("ChildERC1155Predicate", () => {
   it("fail deposit tokens of unknown child token: unmapped token", async () => {
     const rootToken = ethers.Wallet.createRandom().address;
     const childToken = await (await ethers.getContractFactory("ChildERC1155")).deploy();
-    await childToken.initialize(rootToken, "TEST", "TEST");
+    await childToken.initialize(rootToken, "TEST");
     let stateSyncData = ethers.utils.defaultAbiCoder.encode(
       ["bytes32", "address", "address", "address", "uint256", "uint256"],
       [
@@ -440,7 +440,7 @@ describe("ChildERC1155Predicate", () => {
   it("fail withdraw tokens of unknown child token: unmapped token", async () => {
     const rootToken = ethers.Wallet.createRandom().address;
     const childToken = await (await ethers.getContractFactory("ChildERC1155")).deploy();
-    await childToken.initialize(rootToken, "TEST", "TEST");
+    await childToken.initialize(rootToken, "TEST");
     await expect(stateReceiverChildERC1155Predicate.withdraw(childToken.address, 0, 1)).to.be.revertedWith(
       "ChildERC1155Predicate: UNMAPPED_TOKEN"
     );


### PR DESCRIPTION
## Map token action

This PR fixes the issue in map token action for ERC 1155. The problem was that `ChildERC1155Predicate` expected data in the following format:
```solidity
abi.encode(bytes32 sig, address rootToken, string name, string uri)
```
whereas `RootERC1155Predicate` was sending data in the following format (basically `name` and `uri` parameters were missing):
```solidity
abi.encode(bytes32 sig, address rootToken)
```
**NOTES**: 
- Also for some reason, `uri` function expects token id as a parameter, although the default ERC1155 implementation does not utilize that parameter, but returns a single URI it holds. Therefore I just hardcoded token id value to 1.

## Batch withdrawal action
Batch withdrawal also contained non-aligned parameters on the root chain vs the child chain predicates.

`ChildERC1155Predicate` was sending data in incorrect format (amounts were omitted):

```solidity
abi.encode(bytes32 sig, address rootToken, address sender, address[] receivers, uint256[] tokenIds)
```
whereas `RootERC1155Predicate` was expecting the correct data:

```solidity
abi.encode(bytes32 sig, address rootToken, address sender, address[] receivers, uint256[] tokenIds, uint256[] amounts)
```