### PR TITLE
Allow single state sync commitment

### DIFF
--- a/contracts/child/StateReceiver.sol
+++ b/contracts/child/StateReceiver.sol
@@ -74,10 +74,15 @@ contract StateReceiver is System {
     function execute(bytes32[] calldata proof, StateSync calldata obj) external {
         StateSyncCommitment memory commitment = getCommitmentByStateSyncId(obj.id);
 
+        uint256 numOfLeaves = commitment.endId - commitment.startId + 1;
+        if (commitment.startId == commitment.endId) {
+            numOfLeaves++;
+        }
+
         require(
             keccak256(abi.encode(obj)).checkMembershipWithHeight(
                 obj.id - commitment.startId,
-                commitment.endId - commitment.startId + 1,
+                numOfLeaves,
                 commitment.root,
                 proof
             ),

--- a/contracts/common/Merkle.sol
+++ b/contracts/common/Merkle.sol
@@ -69,7 +69,7 @@ library Merkle {
         require(proofHeight == numLeaves.log2(Math.Rounding.Up), "INVALID_PROOF_LENGTH");
         // if the proof is of size n, the tree height will be n+1
         // in a tree of height n+1, max possible leaves are 2^n
-        require(index < numLeaves, "INVALID_LEAF_INDEX");
+        require(index <= numLeaves, "INVALID_LEAF_INDEX");
         // refuse to accept padded leaves as proof
         require(leaf != bytes32(0), "INVALID_LEAF");
 

--- a/contracts/common/Merkle.sol
+++ b/contracts/common/Merkle.sol
@@ -69,7 +69,7 @@ library Merkle {
         require(proofHeight == numLeaves.log2(Math.Rounding.Up), "INVALID_PROOF_LENGTH");
         // if the proof is of size n, the tree height will be n+1
         // in a tree of height n+1, max possible leaves are 2^n
-        require(index <= numLeaves, "INVALID_LEAF_INDEX");
+        require(index < numLeaves, "INVALID_LEAF_INDEX");
         // refuse to accept padded leaves as proof
         require(leaf != bytes32(0), "INVALID_LEAF");
 


### PR DESCRIPTION
This PR relaxes assertion so that it allows having a commitment with just a single state sync event. Prior to this change, it was reverting because of this condition:

`require(proofHeight == numLeaves.log2(Math.Rounding.Up), "INVALID_PROOF_LENGTH");`