### PR TITLE
fix: relax param req

### DIFF
--- a/contracts/child/NetworkParams.sol
+++ b/contracts/child/NetworkParams.sol
@@ -70,9 +70,7 @@ contract NetworkParams is Ownable2Step, Initializable {
                 initParams.newWithdrawalWaitPeriod != 0 &&
                 initParams.newBlockTime != 0 &&
                 initParams.newBlockTimeDrift != 0 &&
-                initParams.newVotingDelay != 0 &&
-                initParams.newVotingPeriod != 0 &&
-                initParams.newProposalThreshold != 0,
+                initParams.newVotingPeriod != 0,
             "NetworkParams: INVALID_INPUT"
         );
         checkpointBlockInterval = initParams.newCheckpointBlockInterval;

--- a/contracts/child/NetworkParams.sol
+++ b/contracts/child/NetworkParams.sol
@@ -206,7 +206,6 @@ contract NetworkParams is Ownable2Step, Initializable {
      * @param newVotingDelay new voting delay
      */
     function setNewVotingDelay(uint256 newVotingDelay) external onlyOwner {
-        require(newVotingDelay != 0, "NetworkParams: INVALID_VOTING_DELAY");
         votingDelay = newVotingDelay;
 
         emit NewVotingDelay(newVotingDelay);
@@ -230,7 +229,6 @@ contract NetworkParams is Ownable2Step, Initializable {
      * @param newProposalThreshold new proposal threshold
      */
     function setNewProposalThreshold(uint256 newProposalThreshold) external onlyOwner {
-        require(newProposalThreshold != 0, "NetworkParams: INVALID_PROPOSAL_THRESHOLD");
         proposalThreshold = newProposalThreshold;
 
         emit NewProposalThreshold(newProposalThreshold);

--- a/test/child/NetworkParams.test.ts
+++ b/test/child/NetworkParams.test.ts
@@ -271,10 +271,6 @@ describe("NetworkParams", () => {
     await stopImpersonatingAccount(accounts[1].address);
   });
 
-  it("set new voting delay fail: invalid input", async () => {
-    await expect(networkParams.setNewVotingDelay(0)).to.be.revertedWith("NetworkParams: INVALID_VOTING_DELAY");
-  });
-
   it("set new voting delay success", async () => {
     initParams.newVotingDelay = 10 ** Math.floor(Math.random() + 6);
     await networkParams.setNewVotingDelay(initParams.newVotingDelay);
@@ -309,12 +305,6 @@ describe("NetworkParams", () => {
 
     await expect(newNetworkParams.setNewProposalThreshold(1)).to.be.revertedWith("Ownable: caller is not the owner");
     await stopImpersonatingAccount(accounts[1].address);
-  });
-
-  it("set new proposal threshold fail: invalid input", async () => {
-    await expect(networkParams.setNewProposalThreshold(0)).to.be.revertedWith(
-      "NetworkParams: INVALID_PROPOSAL_THRESHOLD"
-    );
   });
 
   it("set new proposal threshold success", async () => {


### PR DESCRIPTION
## Motivation

Governance: allow some network parameters to be zero.

## Solution

Remove the non-zero requirements for `votingDelay` and `proposalThreshold`.