### PR TITLE
Partial unstake when slashed, instead of entire stake

### DIFF
--- a/contracts/root/staking/StakeManager.sol
+++ b/contracts/root/staking/StakeManager.sol
@@ -70,7 +70,7 @@ contract StakeManager is IStakeManager, Initializable, StakeManagerChildData, St
         if (amount > stake) amount = stake;
         _removeStake(validator, id, amount);
         _withdrawStake(validator, msg.sender, amount);
-        emit StakeRemoved(id, validator, stake);
+        emit StakeRemoved(id, validator, amount);
         emit ValidatorSlashed(id, validator, amount);
     }
 

--- a/contracts/root/staking/StakeManager.sol
+++ b/contracts/root/staking/StakeManager.sol
@@ -68,7 +68,7 @@ contract StakeManager is IStakeManager, Initializable, StakeManagerChildData, St
         uint256 id = idFor(msg.sender);
         uint256 stake = _stakeOf(validator, id);
         if (amount > stake) amount = stake;
-        _removeStake(validator, id, stake);
+        _removeStake(validator, id, amount);
         _withdrawStake(validator, msg.sender, amount);
         emit StakeRemoved(id, validator, stake);
         emit ValidatorSlashed(id, validator, amount);

--- a/test/forge/root/staking/StakeManager.t.sol
+++ b/test/forge/root/staking/StakeManager.t.sol
@@ -159,22 +159,22 @@ contract StakeManager_SlashStake is Staked, StakeManager {
     function test_SlashStakeFor(uint256 amount) public {
         if (amount > maxAmount) amount = maxAmount;
         vm.expectEmit(true, true, true, true);
-        emit StakeRemoved(id, address(this), stakeManager.stakeOf(address(this), id));
+        emit StakeRemoved(id, address(this), amount);
         vm.expectEmit(true, true, true, true);
         emit ValidatorSlashed(id, address(this), amount);
         vm.prank(address(supernetManager));
         stakeManager.slashStakeOf(address(this), amount);
-        assertEq(stakeManager.stakeOf(address(this), id), 0, "should be unstaked completely");
+        assertEq(
+            stakeManager.stakeOf(address(this), id),
+            maxAmount-amount,
+            "should be unstaked by slashed amount"
+        );
         assertEq(
             stakeManager.withdrawableStake(address(this)),
-            maxAmount - amount,
+            0,
             "withdrawable stake should be reduced by the slashed amount"
         );
-        assertEq(
-            token.balanceOf(address(supernetManager)),
-            amount,
-            "supernet manager should receive the slashed amount"
-        );
+        assertEq(token.balanceOf(address(supernetManager)), amount, "supernet manager should receive the slashed amount");
     }
 }
 


### PR DESCRIPTION
This PR fixes the slashed amount on the `StakeManager` contract. Prior to this change, the entire stake was slashed, instead of the calculated amount.