### PR TITLE
Issue with balanceOfAt and totalSupplyAt when commit epoch and distributeRewardFor are in the same block

### DIFF
--- a/contracts/child/validator/RewardPool.sol
+++ b/contracts/child/validator/RewardPool.sol
@@ -52,14 +52,14 @@ contract RewardPool is IRewardPool, System, Initializable {
         uint256 reward = (networkParams.epochReward() * totalBlocks) / epochSize;
         // TODO disincentivize long epoch times
 
-        uint256 totalSupply = validatorSet.totalSupplyAt(epochId);
+        uint256 totalSupply = IERC20Upgradeable(address(validatorSet)).totalSupply();
         uint256 length = uptime.length;
         uint256 totalReward = 0;
         for (uint256 i = 0; i < length; i++) {
             Uptime memory data = uptime[i];
             require(data.signedBlocks <= totalBlocks, "SIGNED_BLOCKS_EXCEEDS_TOTAL");
             // slither-disable-next-line calls-loop
-            uint256 balance = validatorSet.balanceOfAt(data.validator, epochId);
+            uint256 balance = IERC20Upgradeable(address(validatorSet)).balanceOf(data.validator);
             // slither-disable-next-line divide-before-multiply
             uint256 validatorReward = (reward * balance * data.signedBlocks) / (totalSupply * totalBlocks);
             pendingRewards[data.validator] += validatorReward;


### PR DESCRIPTION
Hello maintainers,

While working on a fork of the Polygon Edge client, I intended to upgrade to the latest development version of the smart contracts. During this process, I encountered an issue:

It appears that on the node side `commitEpoch` and `distributeRewardFor` transactions are both added in the same block at the end of each epoch. However, utilizing historical data functions, namely balanceOfAt and totalSupplyAt, leads to reverts when both commit epoch and distributeRewardFor are mined in the same block. To address this, I've updated it to use the most recent data.

If there's any context or nuances I might be missing, I'd greatly appreciate any insights or corrections.

Attached is a simple test that highlights the aforementioned issue:

```
import { expect } from "chai";
import { ethers, network } from "hardhat";

describe("My test", () => {
  it("should pass", async () => {
    const accounts = await ethers.getSigners();
    const random = accounts[6];

    const networkParamsFactory = await ethers.getContractFactory("NetworkParams");
    const networkParams = await networkParamsFactory.deploy();
    await networkParams.deployed();
    const initParams = {
      newOwner: random.address,
      newCheckpointBlockInterval: 5, // in blocks
      newEpochSize: 10, // in blocks
      newEpochReward: 1000000000000000, // in wei
      newSprintSize: 100, // in blocks
      newMinValidatorSetSize: 1,
      newMaxValidatorSetSize: 10,
      newWithdrawalWaitPeriod: 2, // in blocks
      newBlockTime: 2, // in seconds
      newBlockTimeDrift: 10, // in seconds
      newVotingDelay: 1000, // in blocks
      newVotingPeriod: 50000, // in blocks
      newProposalThreshold: 2, // in percent
    };
    await networkParams.initialize(initParams);

    const validaatorSetFactory = await ethers.getContractFactory("ValidatorSet");
    const validatorSet = await validaatorSetFactory.deploy();
    await validatorSet.deployed();
    await validatorSet.initialize(random.address, random.address, random.address, networkParams.address, []);

    const RewardPoolFactory = await ethers.getContractFactory("RewardPool");
    const rewardPool = await RewardPoolFactory.deploy();
    await rewardPool.deployed();
    await rewardPool.initialize(random.address, random.address, validatorSet.address, networkParams.address);

    await network.provider.request({
      method: "hardhat_impersonateAccount",
      params: ["0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE"],
    });

    const systemSigner = await ethers.getSigner("0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE");
    const systemValidator = validatorSet.connect(systemSigner);
    const systemRewardPool = rewardPool.connect(systemSigner);

    await network.provider.send("evm_setAutomine", [false]);

    const epoch = {
      startBlock: 1,
      endBlock: 10,
      epochRoot: ethers.utils.randomBytes(32),
    };
    await systemValidator.commitEpoch(1, epoch, 10);

    const uptime = [
      {
        validator: random.address,
        signedBlocks: 10,
      },
    ];

    await network.provider.send("evm_setAutomine", [true]);

    // Proof that when commitEpoch and distributeRewardFor are mined in the same block, the latter fails
    await expect(systemRewardPool.distributeRewardFor(1, uptime, 10)).to.be.revertedWith(
      "ValidatorSet: epoch is not finished yet"
    );
  });
});

```