### PR TITLE
Root contracts migration

### DIFF
--- a/contracts/interfaces/root/staking/ICustomSupernetManager.sol
+++ b/contracts/interfaces/root/staking/ICustomSupernetManager.sol
@@ -10,6 +10,19 @@ struct Validator {
     bool isActive;
 }
 
+struct SupernetInitParams {
+    address newStakeManager;
+    address newBls;
+    address newStateSender;
+    address newMatic;
+    address newChildValidatorSet;
+    address newExitHelper;
+    string newDomain;
+    GenesisValidator[] genesisSet;
+    address[] validatorAddresses;
+    Validator[] validators;
+}
+
 /**
     @title ICustomSupernetManager
     @author Polygon Technology (@gretzke)

--- a/contracts/root/ExitHelper.sol
+++ b/contracts/root/ExitHelper.sol
@@ -24,11 +24,26 @@ contract ExitHelper is IExitHelper, Initializable {
      * @param newCheckpointManager Address of the checkpoint manager contract
      */
     function initialize(ICheckpointManager newCheckpointManager) external initializer {
-        require(
-            address(newCheckpointManager) != address(0) && address(newCheckpointManager).code.length != 0,
-            "ExitHelper: INVALID_ADDRESS"
-        );
-        checkpointManager = newCheckpointManager;
+        _setInitialValues(newCheckpointManager);
+    }
+
+    /**
+     * @notice Initialize the contract with migrated data from old contract version
+     * @dev The checkpoint manager contract must be deployed first
+     * @param newCheckpointManager Address of the checkpoint manager contract
+     * @param processedExits_ Ids of processed exit events
+     */
+    function initializeOnMigration(
+        ICheckpointManager newCheckpointManager,
+        uint256[] calldata processedExits_
+    ) external initializer {
+        _setInitialValues(newCheckpointManager);
+
+        uint256 length = processedExits_.length;
+        for (uint256 i = 0; i < length; i++) {
+            uint256 exitId = processedExits_[i];
+            processedExits[exitId] = true;
+        }
     }
 
     /**
@@ -97,6 +112,14 @@ contract ExitHelper is IExitHelper, Initializable {
         if (!success) processedExits[id] = false;
 
         emit ExitProcessed(id, success, returnData);
+    }
+
+    function _setInitialValues(ICheckpointManager newCheckpointManager) private {
+        require(
+            address(newCheckpointManager) != address(0) && address(newCheckpointManager).code.length != 0,
+            "ExitHelper: INVALID_ADDRESS"
+        );
+        checkpointManager = newCheckpointManager;
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/root/StateSender.sol
+++ b/contracts/root/StateSender.sol
@@ -1,13 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../interfaces/IStateSender.sol";
 
-contract StateSender is IStateSender {
+contract StateSender is IStateSender, Initializable {
     uint256 public constant MAX_LENGTH = 2048;
     uint256 public counter;
 
     event StateSynced(uint256 indexed id, address indexed sender, address indexed receiver, bytes data);
+
+    /**
+     * @notice initializer for StateSender, sets the initial id for state sync events
+     * @param lastId last state sync id on old contract
+     */
+    function initializeOnMigration(uint256 lastId) public initializer {
+        counter = lastId;
+    }
 
     /**
      *

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -14,19 +14,6 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
     using SafeERC20 for IERC20;
     using GenesisLib for GenesisSet;
 
-    struct SupernetInitParams {
-        address newStakeManager;
-        address newBls;
-        address newStateSender;
-        address newMatic;
-        address newChildValidatorSet;
-        address newExitHelper;
-        string newDomain;
-        GenesisValidator[] genesisSet;
-        address[] validatorAddresses;
-        Validator[] validators;
-    }
-
     bytes32 private constant _STAKE_SIG = keccak256("STAKE");
     bytes32 private constant _UNSTAKE_SIG = keccak256("UNSTAKE");
     bytes32 private constant _SLASH_SIG = keccak256("SLASH");

--- a/docs/root/CheckpointManager.md
+++ b/docs/root/CheckpointManager.md
@@ -332,7 +332,7 @@ function initialize(contract IBLS newBls, contract IBN256G2 newBn256G2, uint256 
 ### initializeOnMigration
 
 ```solidity
-function initializeOnMigration(contract IBLS newBls, contract IBN256G2 newBn256G2, uint256 chainId_, ICheckpointManager.Validator[] existingValidatorSet, ICheckpointManager.Checkpoint[] existingCheckpoints) external nonpayable
+function initializeOnMigration(contract IBLS newBls, contract IBN256G2 newBn256G2, uint256 chainId_, ICheckpointManager.Validator[] existingValidatorSet, ICheckpointManager.Checkpoint[] existingCheckpoints, uint256[] existingCheckpointBlockNumbers) external nonpayable
 ```
 
 
@@ -348,6 +348,7 @@ function initializeOnMigration(contract IBLS newBls, contract IBN256G2 newBn256G
 | chainId_ | uint256 | undefined |
 | existingValidatorSet | ICheckpointManager.Validator[] | undefined |
 | existingCheckpoints | ICheckpointManager.Checkpoint[] | undefined |
+| existingCheckpointBlockNumbers | uint256[] | undefined |
 
 ### submit
 

--- a/docs/root/CheckpointManager.md
+++ b/docs/root/CheckpointManager.md
@@ -329,6 +329,26 @@ function initialize(contract IBLS newBls, contract IBN256G2 newBn256G2, uint256 
 | chainId_ | uint256 | undefined |
 | newValidatorSet | ICheckpointManager.Validator[] | undefined |
 
+### initializeOnMigration
+
+```solidity
+function initializeOnMigration(contract IBLS newBls, contract IBN256G2 newBn256G2, uint256 chainId_, ICheckpointManager.Validator[] existingValidatorSet, ICheckpointManager.Checkpoint[] existingCheckpoints) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newBls | contract IBLS | undefined |
+| newBn256G2 | contract IBN256G2 | undefined |
+| chainId_ | uint256 | undefined |
+| existingValidatorSet | ICheckpointManager.Validator[] | undefined |
+| existingCheckpoints | ICheckpointManager.Checkpoint[] | undefined |
+
 ### submit
 
 ```solidity

--- a/docs/root/ExitHelper.md
+++ b/docs/root/ExitHelper.md
@@ -95,6 +95,23 @@ Initialize the contract with the checkpoint manager address
 |---|---|---|
 | newCheckpointManager | contract ICheckpointManager | Address of the checkpoint manager contract |
 
+### initializeOnMigration
+
+```solidity
+function initializeOnMigration(contract ICheckpointManager newCheckpointManager, uint256[] processedExits_) external nonpayable
+```
+
+Initialize the contract with migrated data from old contract version
+
+*The checkpoint manager contract must be deployed first*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newCheckpointManager | contract ICheckpointManager | Address of the checkpoint manager contract |
+| processedExits_ | uint256[] | Ids of processed exit events |
+
 ### processedExits
 
 ```solidity

--- a/docs/root/StateSender.md
+++ b/docs/root/StateSender.md
@@ -44,6 +44,22 @@ function counter() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### initializeOnMigration
+
+```solidity
+function initializeOnMigration(uint256 lastId) external nonpayable
+```
+
+initializer for StateSender, sets the initial id for state sync events
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| lastId | uint256 | last state sync id on old contract |
+
 ### syncState
 
 ```solidity
@@ -64,6 +80,22 @@ Generates sync state event based on receiver and data. Anyone can call this meth
 
 
 ## Events
+
+### Initialized
+
+```solidity
+event Initialized(uint8 version)
+```
+
+
+
+*Triggered when the contract has been initialized or reinitialized.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| version  | uint8 | undefined |
 
 ### StateSynced
 

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -119,7 +119,7 @@ function id() external view returns (uint256)
 ### initialize
 
 ```solidity
-function initialize(address newStakeManager, address newBls, address newStateSender, address newMatic, address newChildValidatorSet, address newExitHelper, string newDomain) external nonpayable
+function initialize(CustomSupernetManager.SupernetInitParams initParams) external nonpayable
 ```
 
 
@@ -130,13 +130,23 @@ function initialize(address newStakeManager, address newBls, address newStateSen
 
 | Name | Type | Description |
 |---|---|---|
-| newStakeManager | address | undefined |
-| newBls | address | undefined |
-| newStateSender | address | undefined |
-| newMatic | address | undefined |
-| newChildValidatorSet | address | undefined |
-| newExitHelper | address | undefined |
-| newDomain | string | undefined |
+| initParams | CustomSupernetManager.SupernetInitParams | undefined |
+
+### initializeOnMigration
+
+```solidity
+function initializeOnMigration(CustomSupernetManager.SupernetInitParams initParams) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| initParams | CustomSupernetManager.SupernetInitParams | undefined |
 
 ### onInit
 

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -119,7 +119,7 @@ function id() external view returns (uint256)
 ### initialize
 
 ```solidity
-function initialize(CustomSupernetManager.SupernetInitParams initParams) external nonpayable
+function initialize(SupernetInitParams initParams) external nonpayable
 ```
 
 
@@ -130,12 +130,12 @@ function initialize(CustomSupernetManager.SupernetInitParams initParams) externa
 
 | Name | Type | Description |
 |---|---|---|
-| initParams | CustomSupernetManager.SupernetInitParams | undefined |
+| initParams | SupernetInitParams | undefined |
 
 ### initializeOnMigration
 
 ```solidity
-function initializeOnMigration(CustomSupernetManager.SupernetInitParams initParams) external nonpayable
+function initializeOnMigration(SupernetInitParams initParams) external nonpayable
 ```
 
 
@@ -146,7 +146,7 @@ function initializeOnMigration(CustomSupernetManager.SupernetInitParams initPara
 
 | Name | Type | Description |
 |---|---|---|
-| initParams | CustomSupernetManager.SupernetInitParams | undefined |
+| initParams | SupernetInitParams | undefined |
 
 ### onInit
 

--- a/test/forge/root/staking/CustomSupernetManager.t.sol
+++ b/test/forge/root/staking/CustomSupernetManager.t.sol
@@ -6,7 +6,7 @@ import "contracts/common/BLS.sol";
 import "contracts/root/StateSender.sol";
 import {ExitHelper} from "contracts/root/ExitHelper.sol";
 import {StakeManager} from "contracts/root/staking/StakeManager.sol";
-import {CustomSupernetManager, Validator, GenesisValidator} from "contracts/root/staking/CustomSupernetManager.sol";
+import {CustomSupernetManager, Validator, GenesisValidator, SupernetInitParams} from "contracts/root/staking/CustomSupernetManager.sol";
 import {MockERC20} from "contracts/mocks/MockERC20.sol";
 import "contracts/interfaces/Errors.sol";
 
@@ -36,15 +36,19 @@ abstract contract Uninitialized is Test {
 abstract contract Initialized is Uninitialized {
     function setUp() public virtual override {
         super.setUp();
-        supernetManager.initialize(
-            address(stakeManager),
-            address(bls),
-            address(stateSender),
-            address(token),
-            childValidatorSet,
-            exitHelper,
-            DOMAIN
-        );
+        SupernetInitParams memory initParams = SupernetInitParams({
+            newStakeManager: address(stakeManager),
+            newBls: address(bls),
+            newStateSender: address(stateSender),
+            newMatic: address(token),
+            newChildValidatorSet: childValidatorSet,
+            newExitHelper: exitHelper,
+            newDomain: DOMAIN,
+            genesisSet: new GenesisValidator[](0),
+            validatorAddresses: new address[](0),
+            validators: new Validator[](0)
+        });
+        supernetManager.initialize(initParams);
     }
 }
 
@@ -163,15 +167,19 @@ abstract contract Slashed is EnabledStaking {
 
 contract CustomSupernetManager_Initialize is Uninitialized {
     function testInititialize() public {
-        supernetManager.initialize(
-            address(stakeManager),
-            address(bls),
-            address(stateSender),
-            address(token),
-            childValidatorSet,
-            exitHelper,
-            DOMAIN
-        );
+        SupernetInitParams memory initParams = SupernetInitParams({
+            newStakeManager: address(stakeManager),
+            newBls: address(bls),
+            newStateSender: address(stateSender),
+            newMatic: address(token),
+            newChildValidatorSet: childValidatorSet,
+            newExitHelper: exitHelper,
+            newDomain: DOMAIN,
+            genesisSet: new GenesisValidator[](0),
+            validatorAddresses: new address[](0),
+            validators: new Validator[](0)
+        });
+        supernetManager.initialize(initParams);
         assertEq(supernetManager.owner(), address(this), "should set owner");
         assertEq((supernetManager.domain()), keccak256(abi.encodePacked(DOMAIN)), "should set and hash DOMAIN");
     }


### PR DESCRIPTION
In order to migrate rootchain contracts from v1.1 to v1.2 we need to add new initialize functions to contracts:

1. `StateSender`
2. `ExitHelper`
3. `CheckpointManager`
4. `CustomSupernetManager`.

so that we can transfer all the necessary data from old contracts to new ones for already running chains.