### PR TITLE
Enable zero epoch rewards

### DIFF
--- a/contracts/child/NetworkParams.sol
+++ b/contracts/child/NetworkParams.sol
@@ -66,7 +66,6 @@ contract NetworkParams is Ownable2Step, Initializable {
             initParams.newOwner != address(0) &&
                 initParams.newCheckpointBlockInterval != 0 &&
                 initParams.newEpochSize != 0 &&
-                initParams.newEpochReward != 0 &&
                 initParams.newSprintSize != 0 &&
                 initParams.newMinValidatorSetSize != 0 &&
                 initParams.newMaxValidatorSetSize != 0 &&
@@ -123,7 +122,6 @@ contract NetworkParams is Ownable2Step, Initializable {
      * @param newEpochReward new epoch reward
      */
     function setNewEpochReward(uint256 newEpochReward) external onlyOwner {
-        require(newEpochReward != 0, "NetworkParams: INVALID_EPOCH_REWARD");
         epochReward = newEpochReward;
 
         emit NewEpochReward(newEpochReward);

--- a/test/child/NetworkParams.test.ts
+++ b/test/child/NetworkParams.test.ts
@@ -129,10 +129,6 @@ describe("NetworkParams", () => {
     await stopImpersonatingAccount(accounts[1].address);
   });
 
-  it("set new epoch reward fail: invalid input", async () => {
-    await expect(networkParams.setNewEpochReward(0)).to.be.revertedWith("NetworkParams: INVALID_EPOCH_REWARD");
-  });
-
   it("set new epoch reward success", async () => {
     initParams.newEpochReward = 10 ** Math.floor(Math.random() + 6);
     await networkParams.setNewEpochReward(initParams.newEpochReward);


### PR DESCRIPTION
There are clients that don't want reward distribution, so we need to enable zero epoch rewards.

This PR removes the check if epoch reward is zero from `NetworkParams` contract.