### PR TITLE
Unable to fund state sync relayer when using rootchain originated native token

### DIFF
--- a/contracts/interfaces/root/IRootERC20Predicate.sol
+++ b/contracts/interfaces/root/IRootERC20Predicate.sol
@@ -49,4 +49,10 @@ interface IRootERC20Predicate is IL2StateReceiver {
      * @return address Address of the child token
      */
     function mapToken(IERC20Metadata rootToken) external returns (address);
+
+    /**
+     * @notice Function that retrieves rootchain token that represents Supernets native token
+     * @return address Address of rootchain token (mapped to Supernets native token)
+     */
+    function nativeTokenRoot() external returns (address);
 }

--- a/contracts/interfaces/root/staking/ICustomSupernetManager.sol
+++ b/contracts/interfaces/root/staking/ICustomSupernetManager.sol
@@ -21,7 +21,7 @@ interface ICustomSupernetManager {
     event RemovedFromWhitelist(address indexed validator);
     event ValidatorRegistered(address indexed validator, uint256[4] blsKey);
     event ValidatorDeactivated(address indexed validator);
-    event AccountPremined(address indexed account, uint256 amount);
+    event GenesisBalanceAdded(address indexed account, uint256 indexed amount);
     event GenesisFinalized(uint256 amountValidators);
     event StakingEnabled();
 

--- a/contracts/interfaces/root/staking/ICustomSupernetManager.sol
+++ b/contracts/interfaces/root/staking/ICustomSupernetManager.sol
@@ -56,8 +56,8 @@ interface ICustomSupernetManager {
     /// @notice returns validator instance based on provided address
     function getValidator(address validator_) external view returns (Validator memory);
 
-    /// @notice premine is used to specify premine information for genesis accounts on the Supernets.
+    /// @notice addGenesisBalance is used to specify genesis balance information for genesis accounts on the Supernets.
     /// It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
     /// @param amount represents the amount to be premined in the genesis.
-    function premine(uint256 amount) external;
+    function addGenesisBalance(uint256 amount) external;
 }

--- a/contracts/interfaces/root/staking/ICustomSupernetManager.sol
+++ b/contracts/interfaces/root/staking/ICustomSupernetManager.sol
@@ -50,9 +50,6 @@ interface ICustomSupernetManager {
     /// @notice returns the genesis validator set with their balances
     function genesisSet() external view returns (GenesisValidator[] memory);
 
-    /// @notice genesisBalances returns genesis accounts balances
-    function genesisBalances() external view returns (uint256[] memory);
-
     /// @notice returns validator instance based on provided address
     function getValidator(address validator_) external view returns (Validator memory);
 
@@ -60,4 +57,8 @@ interface ICustomSupernetManager {
     /// It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
     /// @param amount represents the amount to be premined in the genesis.
     function addGenesisBalance(uint256 amount) external;
+
+    /// @notice getGenesisBalance returns balance for the given account address.
+    /// @param account address of the account
+    function getGenesisBalance(address account) external view returns (uint256);
 }

--- a/contracts/interfaces/root/staking/ICustomSupernetManager.sol
+++ b/contracts/interfaces/root/staking/ICustomSupernetManager.sol
@@ -50,6 +50,9 @@ interface ICustomSupernetManager {
     /// @notice returns the genesis validator set with their balances
     function genesisSet() external view returns (GenesisValidator[] memory);
 
+    /// @notice genesisBalances returns genesis accounts balances
+    function genesisBalances() external view returns (uint256[] memory);
+
     /// @notice returns validator instance based on provided address
     function getValidator(address validator_) external view returns (Validator memory);
 

--- a/contracts/interfaces/root/staking/ICustomSupernetManager.sol
+++ b/contracts/interfaces/root/staking/ICustomSupernetManager.sol
@@ -21,6 +21,7 @@ interface ICustomSupernetManager {
     event RemovedFromWhitelist(address indexed validator);
     event ValidatorRegistered(address indexed validator, uint256[4] blsKey);
     event ValidatorDeactivated(address indexed validator);
+    event AccountPremined(address indexed account, uint256 amount);
     event GenesisFinalized(uint256 amountValidators);
     event StakingEnabled();
 
@@ -51,4 +52,9 @@ interface ICustomSupernetManager {
 
     /// @notice returns validator instance based on provided address
     function getValidator(address validator_) external view returns (Validator memory);
+
+    /// @notice premine is used to specify premine information for genesis accounts on the Supernets.
+    /// It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
+    /// @param amount represents the amount to be premined in the genesis.
+    function premine(uint256 amount) external;
 }

--- a/contracts/interfaces/root/staking/ICustomSupernetManager.sol
+++ b/contracts/interfaces/root/staking/ICustomSupernetManager.sol
@@ -57,8 +57,4 @@ interface ICustomSupernetManager {
     /// It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
     /// @param amount represents the amount to be premined in the genesis.
     function addGenesisBalance(uint256 amount) external;
-
-    /// @notice getGenesisBalance returns balance for the given account address.
-    /// @param account address of the account
-    function getGenesisBalance(address account) external view returns (uint256);
 }

--- a/contracts/lib/GenesisLib.sol
+++ b/contracts/lib/GenesisLib.sol
@@ -21,7 +21,6 @@ struct GenesisSet {
     GenesisValidator[] genesisValidators;
     GenesisStatus status;
     mapping(address => uint256) indices;
-    uint256[] balances;
 }
 
 library GenesisLib {
@@ -31,7 +30,7 @@ library GenesisLib {
      * @param validator address of the validator
      * @param stake amount to add to the validators genesis stake
      */
-    function insert(GenesisSet storage self, address validator, uint256 stake, uint256 balance) internal {
+    function insert(GenesisSet storage self, address validator, uint256 stake) internal {
         assert(self.status == GenesisStatus.NOT_STARTED);
         uint256 index = self.indices[validator];
         if (index == 0) {
@@ -40,13 +39,11 @@ library GenesisLib {
             index = self.genesisValidators.length + 1;
             self.indices[validator] = index;
             self.genesisValidators.push(GenesisValidator(validator, stake));
-            self.balances.push(balance);
         } else {
             // update values
             uint256 idx = _indexOf(self, validator);
             GenesisValidator storage genesisValidator = self.genesisValidators[idx];
             genesisValidator.initialStake += stake;
-            self.balances[idx] += balance;
         }
     }
 

--- a/contracts/lib/GenesisLib.sol
+++ b/contracts/lib/GenesisLib.sol
@@ -13,7 +13,7 @@ enum GenesisStatus {
 }
 
 struct GenesisValidator {
-    address validator;
+    address addr;
     uint256 initialStake;
     uint256 balance;
 }

--- a/contracts/lib/GenesisLib.sol
+++ b/contracts/lib/GenesisLib.sol
@@ -15,13 +15,13 @@ enum GenesisStatus {
 struct GenesisValidator {
     address addr;
     uint256 initialStake;
-    uint256 balance;
 }
 
 struct GenesisSet {
     GenesisValidator[] genesisValidators;
     GenesisStatus status;
     mapping(address => uint256) indices;
+    uint256[] balances;
 }
 
 library GenesisLib {
@@ -39,12 +39,14 @@ library GenesisLib {
             // use index starting with 1, 0 is empty by default
             index = self.genesisValidators.length + 1;
             self.indices[validator] = index;
-            self.genesisValidators.push(GenesisValidator(validator, stake, balance));
+            self.genesisValidators.push(GenesisValidator(validator, stake));
+            self.balances.push(balance);
         } else {
             // update values
-            GenesisValidator storage genesisValidator = self.genesisValidators[_indexOf(self, validator)];
+            uint256 idx = _indexOf(self, validator);
+            GenesisValidator storage genesisValidator = self.genesisValidators[idx];
             genesisValidator.initialStake += stake;
-            genesisValidator.balance += balance;
+            self.balances[idx] += balance;
         }
     }
 

--- a/contracts/lib/GenesisLib.sol
+++ b/contracts/lib/GenesisLib.sol
@@ -15,6 +15,7 @@ enum GenesisStatus {
 struct GenesisValidator {
     address validator;
     uint256 initialStake;
+    uint256 balance;
 }
 
 struct GenesisSet {
@@ -30,7 +31,7 @@ library GenesisLib {
      * @param validator address of the validator
      * @param stake amount to add to the validators genesis stake
      */
-    function insert(GenesisSet storage self, address validator, uint256 stake) internal {
+    function insert(GenesisSet storage self, address validator, uint256 stake, uint256 balance) internal {
         assert(self.status == GenesisStatus.NOT_STARTED);
         uint256 index = self.indices[validator];
         if (index == 0) {
@@ -38,11 +39,12 @@ library GenesisLib {
             // use index starting with 1, 0 is empty by default
             index = self.genesisValidators.length + 1;
             self.indices[validator] = index;
-            self.genesisValidators.push(GenesisValidator(validator, stake));
+            self.genesisValidators.push(GenesisValidator(validator, stake, balance));
         } else {
             // update values
             GenesisValidator storage genesisValidator = self.genesisValidators[_indexOf(self, validator)];
             genesisValidator.initialStake += stake;
+            genesisValidator.balance += balance;
         }
     }
 

--- a/contracts/root/RootERC20Predicate.sol
+++ b/contracts/root/RootERC20Predicate.sol
@@ -19,7 +19,7 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
     bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
     bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
     mapping(address => address) public rootTokenToChildToken;
-    address public nativeTokenRoot;
+    address private _nativeTokenRootAddress;
 
     /**
      * @notice Initialization function for RootERC20Predicate
@@ -33,7 +33,7 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         address newExitHelper,
         address newChildERC20Predicate,
         address newChildTokenTemplate,
-        address newNativeTokenRoot
+        address nativeTokenRootAddress
     ) external initializer {
         require(
             newStateSender != address(0) &&
@@ -46,10 +46,10 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         exitHelper = newExitHelper;
         childERC20Predicate = newChildERC20Predicate;
         childTokenTemplate = newChildTokenTemplate;
-        if (nativeTokenRoot != address(0)) {
-            nativeTokenRoot = newNativeTokenRoot;
-            rootTokenToChildToken[nativeTokenRoot] = 0x0000000000000000000000000000000000001010;
-            emit TokenMapped(nativeTokenRoot, 0x0000000000000000000000000000000000001010);
+        if (nativeTokenRootAddress != address(0)) {
+            _nativeTokenRootAddress = nativeTokenRootAddress;
+            rootTokenToChildToken[nativeTokenRootAddress] = 0x0000000000000000000000000000000000001010;
+            emit TokenMapped(nativeTokenRootAddress, 0x0000000000000000000000000000000000001010);
         }
     }
 
@@ -108,6 +108,13 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         emit TokenMapped(address(rootToken), childToken);
 
         return childToken;
+    }
+
+    /**
+     * @inheritdoc IRootERC20Predicate
+     */
+    function nativeTokenRoot() external view returns (address) {
+        return _nativeTokenRootAddress;
     }
 
     function _deposit(IERC20Metadata rootToken, address receiver, uint256 amount) private {

--- a/contracts/root/RootERC20Predicate.sol
+++ b/contracts/root/RootERC20Predicate.sol
@@ -18,8 +18,8 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
     bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
     bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
     bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
-    address private _nativeTokenRootAddress;
     mapping(address => address) public rootTokenToChildToken;
+    address public nativeTokenRoot;
 
     /**
      * @notice Initialization function for RootERC20Predicate
@@ -33,7 +33,7 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         address newExitHelper,
         address newChildERC20Predicate,
         address newChildTokenTemplate,
-        address nativeTokenRootAddress
+        address newNativeTokenRoot
     ) external initializer {
         require(
             newStateSender != address(0) &&
@@ -46,10 +46,10 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         exitHelper = newExitHelper;
         childERC20Predicate = newChildERC20Predicate;
         childTokenTemplate = newChildTokenTemplate;
-        if (nativeTokenRootAddress != address(0)) {
-            _nativeTokenRootAddress = nativeTokenRootAddress;
-            rootTokenToChildToken[nativeTokenRootAddress] = 0x0000000000000000000000000000000000001010;
-            emit TokenMapped(nativeTokenRootAddress, 0x0000000000000000000000000000000000001010);
+        if (nativeTokenRoot != address(0)) {
+            nativeTokenRoot = newNativeTokenRoot;
+            rootTokenToChildToken[nativeTokenRoot] = 0x0000000000000000000000000000000000001010;
+            emit TokenMapped(nativeTokenRoot, 0x0000000000000000000000000000000000001010);
         }
     }
 
@@ -110,13 +110,6 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         return childToken;
     }
 
-    /**
-     * @inheritdoc IRootERC20Predicate
-     */
-    function nativeTokenRoot() external view returns (address) {
-        return _nativeTokenRootAddress;
-    }
-
     function _deposit(IERC20Metadata rootToken, address receiver, uint256 amount) private {
         address childToken = rootTokenToChildToken[address(rootToken)];
 
@@ -147,5 +140,5 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
     }
 
     // slither-disable-next-line unused-state,naming-convention
-    uint256[50] private __gap;
+    uint256[49] private __gap;
 }

--- a/contracts/root/RootERC20Predicate.sol
+++ b/contracts/root/RootERC20Predicate.sol
@@ -19,7 +19,7 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
     bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
     bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
     mapping(address => address) public rootTokenToChildToken;
-    address private _nativeTokenRootAddress;
+    address public nativeTokenRoot;
 
     /**
      * @notice Initialization function for RootERC20Predicate
@@ -33,7 +33,7 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         address newExitHelper,
         address newChildERC20Predicate,
         address newChildTokenTemplate,
-        address nativeTokenRootAddress
+        address newNativeTokenRoot
     ) external initializer {
         require(
             newStateSender != address(0) &&
@@ -46,10 +46,10 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         exitHelper = newExitHelper;
         childERC20Predicate = newChildERC20Predicate;
         childTokenTemplate = newChildTokenTemplate;
-        if (nativeTokenRootAddress != address(0)) {
-            _nativeTokenRootAddress = nativeTokenRootAddress;
-            rootTokenToChildToken[nativeTokenRootAddress] = 0x0000000000000000000000000000000000001010;
-            emit TokenMapped(nativeTokenRootAddress, 0x0000000000000000000000000000000000001010);
+        if (newNativeTokenRoot != address(0)) {
+            nativeTokenRoot = newNativeTokenRoot;
+            rootTokenToChildToken[nativeTokenRoot] = 0x0000000000000000000000000000000000001010;
+            emit TokenMapped(nativeTokenRoot, 0x0000000000000000000000000000000000001010);
         }
     }
 
@@ -108,13 +108,6 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         emit TokenMapped(address(rootToken), childToken);
 
         return childToken;
-    }
-
-    /**
-     * @inheritdoc IRootERC20Predicate
-     */
-    function nativeTokenRoot() external view returns (address) {
-        return _nativeTokenRootAddress;
     }
 
     function _deposit(IERC20Metadata rootToken, address receiver, uint256 amount) private {

--- a/contracts/root/RootERC20Predicate.sol
+++ b/contracts/root/RootERC20Predicate.sol
@@ -18,6 +18,7 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
     bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
     bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
     bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
+    address private _nativeTokenRootAddress;
     mapping(address => address) public rootTokenToChildToken;
 
     /**
@@ -46,6 +47,7 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         childERC20Predicate = newChildERC20Predicate;
         childTokenTemplate = newChildTokenTemplate;
         if (nativeTokenRootAddress != address(0)) {
+            _nativeTokenRootAddress = nativeTokenRootAddress;
             rootTokenToChildToken[nativeTokenRootAddress] = 0x0000000000000000000000000000000000001010;
             emit TokenMapped(nativeTokenRootAddress, 0x0000000000000000000000000000000000001010);
         }
@@ -106,6 +108,13 @@ contract RootERC20Predicate is Initializable, IRootERC20Predicate {
         emit TokenMapped(address(rootToken), childToken);
 
         return childToken;
+    }
+
+    /**
+     * @inheritdoc IRootERC20Predicate
+     */
+    function nativeTokenRoot() external view returns (address) {
+        return _nativeTokenRootAddress;
     }
 
     function _deposit(IERC20Metadata rootToken, address receiver, uint256 amount) private {

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -150,7 +150,6 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
         require(!_genesis.completed(), "CustomSupernetManager: GENESIS_SET_IS_ALREADY_FINALIZED");
 
         _genesis.insert(msg.sender, 0, amount);
-
         nativeTokenRoot.safeTransferFrom(msg.sender, address(_rootERC20Predicate), amount);
 
         // slither-disable-next-line reentrancy-events

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -152,6 +152,7 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
         nativeTokenRoot.safeTransferFrom(msg.sender, address(_rootERC20Predicate), amount);
         _genesis.insert(msg.sender, 0, amount);
 
+        // slither-disable-next-line reentrancy-events
         emit AccountPremined(msg.sender, amount);
     }
 

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -159,10 +159,12 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
         nativeTokenRoot.safeTransferFrom(msg.sender, address(_rootERC20Predicate), amount);
 
         // slither-disable-next-line reentrancy-events
-        emit AccountPremined(msg.sender, amount);
+        emit GenesisBalanceAdded(msg.sender, amount);
     }
 
-    /// @inheritdoc ICustomSupernetManager
+    /**
+     * @inheritdoc ICustomSupernetManager
+     */
     function getGenesisBalance(address account) external view returns (uint256) {
         return _genesisBalances[account];
     }

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -127,6 +127,13 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
     }
 
     /**
+     * @inheritdoc ICustomSupernetManager
+     */
+    function genesisBalances() external view returns (uint256[] memory) {
+        return _genesis.balances;
+    }
+
+    /**
      *
      * @inheritdoc ICustomSupernetManager
      */

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -145,7 +145,7 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
      *
      * @inheritdoc ICustomSupernetManager
      */
-    function premine(uint256 amount) external {
+    function addGenesisBalance(uint256 amount) external {
         if (address(_rootERC20Predicate) == address(0)) {
             revert Unauthorized("CustomSupernetManager: UNDEFINED_ROOT_ERC20_PREDICATE");
         }
@@ -215,5 +215,5 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
     }
 
     // slither-disable-next-line unused-state,naming-convention
-    uint256[49] private __gap;
+    uint256[48] private __gap;
 }

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -29,7 +29,7 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
     GenesisSet private _genesis;
     mapping(address => Validator) public validators;
     IRootERC20Predicate private _rootERC20Predicate;
-    mapping(address => uint256) private _genesisBalances;
+    mapping(address => uint256) public genesisBalances;
 
     modifier onlyValidator(address validator) {
         if (!validators[validator].isActive) revert Unauthorized("VALIDATOR");
@@ -153,20 +153,13 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
 
         // we need to track EOAs as well in the genesis set, in order to be able to query genesisBalances mapping
         _genesis.insert(msg.sender, 0);
-        _genesisBalances[msg.sender] = amount;
+        genesisBalances[msg.sender] = amount;
 
         // lock native tokens on the root erc20 predicate
         nativeTokenRoot.safeTransferFrom(msg.sender, address(_rootERC20Predicate), amount);
 
         // slither-disable-next-line reentrancy-events
         emit GenesisBalanceAdded(msg.sender, amount);
-    }
-
-    /**
-     * @inheritdoc ICustomSupernetManager
-     */
-    function getGenesisBalance(address account) external view returns (uint256) {
-        return _genesisBalances[account];
     }
 
     function _onStake(address validator, uint256 amount) internal override onlyValidator(validator) {

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -23,12 +23,12 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
     IERC20 private _matic;
     address private _childValidatorSet;
     address private _exitHelper;
-    IRootERC20Predicate private _rootERC20Predicate;
 
     bytes32 public domain;
 
     GenesisSet private _genesis;
     mapping(address => Validator) public validators;
+    IRootERC20Predicate private _rootERC20Predicate;
 
     modifier onlyValidator(address validator) {
         if (!validators[validator].isActive) revert Unauthorized("VALIDATOR");
@@ -149,8 +149,9 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
         }
         require(!_genesis.completed(), "CustomSupernetManager: GENESIS_SET_IS_ALREADY_FINALIZED");
 
-        nativeTokenRoot.safeTransferFrom(msg.sender, address(_rootERC20Predicate), amount);
         _genesis.insert(msg.sender, 0, amount);
+
+        nativeTokenRoot.safeTransferFrom(msg.sender, address(_rootERC20Predicate), amount);
 
         // slither-disable-next-line reentrancy-events
         emit AccountPremined(msg.sender, amount);
@@ -208,5 +209,5 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
     }
 
     // slither-disable-next-line unused-state,naming-convention
-    uint256[50] private __gap;
+    uint256[49] private __gap;
 }

--- a/contracts/root/staking/CustomSupernetManager.sol
+++ b/contracts/root/staking/CustomSupernetManager.sol
@@ -153,7 +153,7 @@ contract CustomSupernetManager is ICustomSupernetManager, Ownable2StepUpgradeabl
 
         // we need to track EOAs as well in the genesis set, in order to be able to query genesisBalances mapping
         _genesis.insert(msg.sender, 0);
-        genesisBalances[msg.sender] = amount;
+        genesisBalances[msg.sender] += amount;
 
         // lock native tokens on the root erc20 predicate
         nativeTokenRoot.safeTransferFrom(msg.sender, address(_rootERC20Predicate), amount);

--- a/docs/interfaces/root/IRootERC20Predicate.md
+++ b/docs/interfaces/root/IRootERC20Predicate.md
@@ -67,6 +67,23 @@ Function to be used for token mapping
 |---|---|---|
 | _0 | address | address Address of the child token |
 
+### nativeTokenRoot
+
+```solidity
+function nativeTokenRoot() external nonpayable returns (address)
+```
+
+Function that retrieves rootchain token that represents Supernets native token
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | address Address of rootchain token (mapped to Supernets native token) |
+
 ### onL2StateReceive
 
 ```solidity

--- a/docs/interfaces/root/staking/ICustomSupernetManager.md
+++ b/docs/interfaces/root/staking/ICustomSupernetManager.md
@@ -89,6 +89,22 @@ called by the exit helpers to either release the stake of a validator or slash i
 | sender | address | undefined |
 | data | bytes | undefined |
 
+### premine
+
+```solidity
+function premine(uint256 amount) external nonpayable
+```
+
+premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| amount | uint256 | represents the amount to be premined in the genesis. |
+
 ### register
 
 ```solidity
@@ -125,6 +141,23 @@ Allows to whitelist validators that are allowed to stake
 
 
 ## Events
+
+### AccountPremined
+
+```solidity
+event AccountPremined(address indexed account, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account `indexed` | address | undefined |
+| amount  | uint256 | undefined |
 
 ### AddedToWhitelist
 

--- a/docs/interfaces/root/staking/ICustomSupernetManager.md
+++ b/docs/interfaces/root/staking/ICustomSupernetManager.md
@@ -65,28 +65,6 @@ returns the genesis validator set with their balances
 |---|---|---|
 | _0 | GenesisValidator[] | undefined |
 
-### getGenesisBalance
-
-```solidity
-function getGenesisBalance(address account) external view returns (uint256)
-```
-
-getGenesisBalance returns balance for the given account address.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| account | address | address of the account |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### getValidator
 
 ```solidity
@@ -183,7 +161,7 @@ event AddedToWhitelist(address indexed validator)
 ### GenesisBalanceAdded
 
 ```solidity
-event GenesisBalanceAdded(address indexed account, uint256 amount)
+event GenesisBalanceAdded(address indexed account, uint256 indexed amount)
 ```
 
 
@@ -195,7 +173,7 @@ event GenesisBalanceAdded(address indexed account, uint256 amount)
 | Name | Type | Description |
 |---|---|---|
 | account `indexed` | address | undefined |
-| amount  | uint256 | undefined |
+| amount `indexed` | uint256 | undefined |
 
 ### GenesisFinalized
 

--- a/docs/interfaces/root/staking/ICustomSupernetManager.md
+++ b/docs/interfaces/root/staking/ICustomSupernetManager.md
@@ -10,6 +10,22 @@ Manages validator access and syncs voting power between the stake manager and va
 
 ## Methods
 
+### addGenesisBalance
+
+```solidity
+function addGenesisBalance(uint256 amount) external nonpayable
+```
+
+premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| amount | uint256 | represents the amount to be premined in the genesis. |
+
 ### enableStaking
 
 ```solidity
@@ -31,6 +47,23 @@ finalizes initial genesis validator set
 
 *only callable by owner*
 
+
+### genesisBalances
+
+```solidity
+function genesisBalances() external view returns (uint256[])
+```
+
+genesisBalances returns genesis accounts balances
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256[] | undefined |
 
 ### genesisSet
 
@@ -88,22 +121,6 @@ called by the exit helpers to either release the stake of a validator or slash i
 | _0 | uint256 | undefined |
 | sender | address | undefined |
 | data | bytes | undefined |
-
-### premine
-
-```solidity
-function premine(uint256 amount) external nonpayable
-```
-
-premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| amount | uint256 | represents the amount to be premined in the genesis. |
 
 ### register
 

--- a/docs/interfaces/root/staking/ICustomSupernetManager.md
+++ b/docs/interfaces/root/staking/ICustomSupernetManager.md
@@ -164,23 +164,6 @@ Allows to whitelist validators that are allowed to stake
 
 ## Events
 
-### AccountPremined
-
-```solidity
-event AccountPremined(address indexed account, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| account `indexed` | address | undefined |
-| amount  | uint256 | undefined |
-
 ### AddedToWhitelist
 
 ```solidity
@@ -196,6 +179,23 @@ event AddedToWhitelist(address indexed validator)
 | Name | Type | Description |
 |---|---|---|
 | validator `indexed` | address | undefined |
+
+### GenesisBalanceAdded
+
+```solidity
+event GenesisBalanceAdded(address indexed account, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account `indexed` | address | undefined |
+| amount  | uint256 | undefined |
 
 ### GenesisFinalized
 

--- a/docs/interfaces/root/staking/ICustomSupernetManager.md
+++ b/docs/interfaces/root/staking/ICustomSupernetManager.md
@@ -48,23 +48,6 @@ finalizes initial genesis validator set
 *only callable by owner*
 
 
-### genesisBalances
-
-```solidity
-function genesisBalances() external view returns (uint256[])
-```
-
-genesisBalances returns genesis accounts balances
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256[] | undefined |
-
 ### genesisSet
 
 ```solidity
@@ -81,6 +64,28 @@ returns the genesis validator set with their balances
 | Name | Type | Description |
 |---|---|---|
 | _0 | GenesisValidator[] | undefined |
+
+### getGenesisBalance
+
+```solidity
+function getGenesisBalance(address account) external view returns (uint256)
+```
+
+getGenesisBalance returns balance for the given account address.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | address of the account |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### getValidator
 

--- a/docs/interfaces/root/staking/ICustomSupernetManager.md
+++ b/docs/interfaces/root/staking/ICustomSupernetManager.md
@@ -16,7 +16,7 @@ Manages validator access and syncs voting power between the stake manager and va
 function addGenesisBalance(uint256 amount) external nonpayable
 ```
 
-premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
+addGenesisBalance is used to specify genesis balance information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
 
 
 

--- a/docs/root/RootERC20Predicate.md
+++ b/docs/root/RootERC20Predicate.md
@@ -150,7 +150,7 @@ function exitHelper() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate, address newNativeTokenRoot) external nonpayable
+function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate, address nativeTokenRootAddress) external nonpayable
 ```
 
 Initialization function for RootERC20Predicate
@@ -165,7 +165,7 @@ Initialization function for RootERC20Predicate
 | newExitHelper | address | Address of ExitHelper to receive withdrawal information from |
 | newChildERC20Predicate | address | Address of child ERC20 predicate to communicate with |
 | newChildTokenTemplate | address | undefined |
-| newNativeTokenRoot | address | undefined |
+| nativeTokenRootAddress | address | undefined |
 
 ### mapToken
 

--- a/docs/root/RootERC20Predicate.md
+++ b/docs/root/RootERC20Predicate.md
@@ -150,7 +150,7 @@ function exitHelper() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate, address nativeTokenRootAddress) external nonpayable
+function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate, address newNativeTokenRoot) external nonpayable
 ```
 
 Initialization function for RootERC20Predicate
@@ -165,7 +165,7 @@ Initialization function for RootERC20Predicate
 | newExitHelper | address | Address of ExitHelper to receive withdrawal information from |
 | newChildERC20Predicate | address | Address of child ERC20 predicate to communicate with |
 | newChildTokenTemplate | address | undefined |
-| nativeTokenRootAddress | address | undefined |
+| newNativeTokenRoot | address | undefined |
 
 ### mapToken
 

--- a/docs/root/RootERC20Predicate.md
+++ b/docs/root/RootERC20Predicate.md
@@ -189,6 +189,23 @@ Function to be used for token mapping
 |---|---|---|
 | _0 | address | address Address of the child token |
 
+### nativeTokenRoot
+
+```solidity
+function nativeTokenRoot() external view returns (address)
+```
+
+Function that retrieves rootchain token that represents Supernets native token
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | address Address of rootchain token (mapped to Supernets native token) |
+
 ### onL2StateReceive
 
 ```solidity

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -76,6 +76,28 @@ finalizes initial genesis validator set
 *only callable by owner*
 
 
+### genesisBalances
+
+```solidity
+function genesisBalances(address) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### genesisSet
 
 ```solidity
@@ -92,28 +114,6 @@ returns the genesis validator set with their balances
 | Name | Type | Description |
 |---|---|---|
 | _0 | GenesisValidator[] | undefined |
-
-### getGenesisBalance
-
-```solidity
-function getGenesisBalance(address account) external view returns (uint256)
-```
-
-getGenesisBalance returns balance for the given account address.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| account | address | address of the account |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
 
 ### getValidator
 
@@ -369,7 +369,7 @@ event AddedToWhitelist(address indexed validator)
 ### GenesisBalanceAdded
 
 ```solidity
-event GenesisBalanceAdded(address indexed account, uint256 amount)
+event GenesisBalanceAdded(address indexed account, uint256 indexed amount)
 ```
 
 
@@ -381,7 +381,7 @@ event GenesisBalanceAdded(address indexed account, uint256 amount)
 | Name | Type | Description |
 |---|---|---|
 | account `indexed` | address | undefined |
-| amount  | uint256 | undefined |
+| amount `indexed` | uint256 | undefined |
 
 ### GenesisFinalized
 

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -350,23 +350,6 @@ Allows to whitelist validators that are allowed to stake
 
 ## Events
 
-### AccountPremined
-
-```solidity
-event AccountPremined(address indexed account, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| account `indexed` | address | undefined |
-| amount  | uint256 | undefined |
-
 ### AddedToWhitelist
 
 ```solidity
@@ -382,6 +365,23 @@ event AddedToWhitelist(address indexed validator)
 | Name | Type | Description |
 |---|---|---|
 | validator `indexed` | address | undefined |
+
+### GenesisBalanceAdded
+
+```solidity
+event GenesisBalanceAdded(address indexed account, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account `indexed` | address | undefined |
+| amount  | uint256 | undefined |
 
 ### GenesisFinalized
 

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -76,23 +76,6 @@ finalizes initial genesis validator set
 *only callable by owner*
 
 
-### genesisBalances
-
-```solidity
-function genesisBalances() external view returns (uint256[])
-```
-
-genesisBalances returns genesis accounts balances
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256[] | undefined |
-
 ### genesisSet
 
 ```solidity
@@ -109,6 +92,28 @@ returns the genesis validator set with their balances
 | Name | Type | Description |
 |---|---|---|
 | _0 | GenesisValidator[] | undefined |
+
+### getGenesisBalance
+
+```solidity
+function getGenesisBalance(address account) external view returns (uint256)
+```
+
+getGenesisBalance returns balance for the given account address.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | address of the account |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### getValidator
 

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -21,6 +21,22 @@ function acceptOwnership() external nonpayable
 *The new owner accepts the ownership transfer.*
 
 
+### addGenesisBalance
+
+```solidity
+function addGenesisBalance(uint256 amount) external nonpayable
+```
+
+premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| amount | uint256 | represents the amount to be premined in the genesis. |
+
 ### domain
 
 ```solidity
@@ -59,6 +75,23 @@ finalizes initial genesis validator set
 
 *only callable by owner*
 
+
+### genesisBalances
+
+```solidity
+function genesisBalances() external view returns (uint256[])
+```
+
+genesisBalances returns genesis accounts balances
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256[] | undefined |
 
 ### genesisSet
 
@@ -223,22 +256,6 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
-
-### premine
-
-```solidity
-function premine(uint256 amount) external nonpayable
-```
-
-premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| amount | uint256 | represents the amount to be premined in the genesis. |
 
 ### register
 

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -119,7 +119,7 @@ function id() external view returns (uint256)
 ### initialize
 
 ```solidity
-function initialize(address newStakeManager, address newBls, address newStateSender, address newMatic, address newChildValidatorSet, address newExitHelper, string newDomain) external nonpayable
+function initialize(address newStakeManager, address newBls, address newStateSender, address newMatic, address newChildValidatorSet, address newExitHelper, address newRootERC20Predicate, string newDomain) external nonpayable
 ```
 
 
@@ -136,6 +136,7 @@ function initialize(address newStakeManager, address newBls, address newStateSen
 | newMatic | address | undefined |
 | newChildValidatorSet | address | undefined |
 | newExitHelper | address | undefined |
+| newRootERC20Predicate | address | undefined |
 | newDomain | string | undefined |
 
 ### onInit
@@ -222,6 +223,22 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### premine
+
+```solidity
+function premine(uint256 amount) external nonpayable
+```
+
+premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| amount | uint256 | represents the amount to be premined in the genesis. |
 
 ### register
 
@@ -310,6 +327,23 @@ Allows to whitelist validators that are allowed to stake
 
 
 ## Events
+
+### AccountPremined
+
+```solidity
+event AccountPremined(address indexed account, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account `indexed` | address | undefined |
+| amount  | uint256 | undefined |
 
 ### AddedToWhitelist
 

--- a/docs/root/staking/CustomSupernetManager.md
+++ b/docs/root/staking/CustomSupernetManager.md
@@ -27,7 +27,7 @@ function acceptOwnership() external nonpayable
 function addGenesisBalance(uint256 amount) external nonpayable
 ```
 
-premine is used to specify premine information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
+addGenesisBalance is used to specify genesis balance information for genesis accounts on the Supernets. It is applicable only in case Supernets native contract is mapped to a pre-existing rootchain ERC20 token.
 
 
 

--- a/script/deployment/DeployNewRootContractSet.s.sol
+++ b/script/deployment/DeployNewRootContractSet.s.sol
@@ -61,6 +61,7 @@ contract DeployNewRootContractSet is
             config.readAddress('["CustomSupernetManager"].newMatic'),
             config.readAddress('["CustomSupernetManager"].newChildValidatorSet'),
             exitHelperProxy,
+            config.readAddress('["CustomSupernetManager"].newRootERC20Predicate'),
             config.readString('["CustomSupernetManager"].newDomain')
         );
     }

--- a/script/deployment/root/staking/DeployCustomSupernetManager.s.sol
+++ b/script/deployment/root/staking/DeployCustomSupernetManager.s.sol
@@ -16,11 +16,21 @@ abstract contract CustomSupernetManagerDeployer is Script {
         address newMatic,
         address newChildValidatorSet,
         address newExitHelper,
+        address newRootERC20Predicate,
         string memory newDomain
     ) internal returns (address logicAddr, address proxyAddr) {
         bytes memory initData = abi.encodeCall(
             CustomSupernetManager.initialize,
-            (newStakeManager, newBls, newStateSender, newMatic, newChildValidatorSet, newExitHelper, newDomain)
+            (
+                newStakeManager,
+                newBls,
+                newStateSender,
+                newMatic,
+                newChildValidatorSet,
+                newExitHelper,
+                newRootERC20Predicate,
+                newDomain
+            )
         );
 
         vm.startBroadcast();
@@ -49,6 +59,7 @@ contract DeployCustomSupernetManager is CustomSupernetManagerDeployer {
         address newMatic,
         address newChildValidatorSet,
         address newExitHelper,
+        address newRootERC20Predicate,
         string memory newDomain
     ) external returns (address logicAddr, address proxyAddr) {
         return
@@ -60,6 +71,7 @@ contract DeployCustomSupernetManager is CustomSupernetManagerDeployer {
                 newMatic,
                 newChildValidatorSet,
                 newExitHelper,
+                newRootERC20Predicate,
                 newDomain
             );
     }

--- a/script/deployment/rootContractSetConfig.json
+++ b/script/deployment/rootContractSetConfig.json
@@ -12,6 +12,7 @@
     "newBls": "",
     "newMatic": "",
     "newChildValidatorSet": "",
+    "newRootERC20Predicate": "",
     "newDomain": ""
   }
 }

--- a/test/forge/root/staking/CustomSupernetManager.t.sol
+++ b/test/forge/root/staking/CustomSupernetManager.t.sol
@@ -389,7 +389,7 @@ contract CustomSupernetManager_Unstake is EnabledStaking {
 }
 
 contract CustomSupernetManager_PremineInitialized is Initialized {
-    uint256 amount = 100 ether;
+    uint256 balance = 100 ether;
     event GenesisBalanceAdded(address indexed account, uint256 indexed amount);
 
     address childERC20Predicate;
@@ -398,7 +398,7 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
 
     function setUp() public virtual override {
         super.setUp();
-        token.mint(bob, amount);
+        token.mint(bob, balance);
         childERC20Predicate = makeAddr("childERC20Predicate");
         childTokenTemplate = makeAddr("childTokenTemplate");
         rootERC20Predicate.initialize(
@@ -412,29 +412,29 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
 
     function test_addGenesisBalance_successful() public {
         vm.startPrank(bob);
-        token.approve(address(supernetManager), amount);
+        token.approve(address(supernetManager), balance);
         vm.expectEmit(true, true, true, true);
-        emit GenesisBalanceAdded(bob, amount);
-        supernetManager.addGenesisBalance(amount);
+        emit GenesisBalanceAdded(bob, balance);
+        supernetManager.addGenesisBalance(balance);
 
         GenesisValidator[] memory genesisAccounts = supernetManager.genesisSet();
         assertEq(genesisAccounts.length, 1, "should set genesisSet");
         GenesisValidator memory account = genesisAccounts[0];
         assertEq(account.addr, bob, "should set validator address");
-        assertEq(account.initialStake, 0, "should set initial stake");
+        assertEq(account.initialStake, 0, "should set initial stake to 0");
 
-        uint256 actualBalance = supernetManager.getGenesisBalance(account.addr);
-        assertEq(actualBalance, amount, "should set balance");
+        uint256 actualBalance = supernetManager.genesisBalances(account.addr);
+        assertEq(actualBalance, balance, "should set genesis balance");
     }
 
     function test_addGenesisBalance_genesisSetFinalizedRevert() public {
         supernetManager.finalizeGenesis();
         supernetManager.enableStaking();
         vm.expectRevert("CustomSupernetManager: GENESIS_SET_IS_ALREADY_FINALIZED");
-        supernetManager.addGenesisBalance(amount);
+        supernetManager.addGenesisBalance(balance);
     }
 
-     function test_addGenesisBalance_invalidAmountRevert() public {
+    function test_addGenesisBalance_invalidAmountRevert() public {
         vm.expectRevert("CustomSupernetManager: INVALID_AMOUNT");
         supernetManager.addGenesisBalance(0);
     }

--- a/test/forge/root/staking/CustomSupernetManager.t.sol
+++ b/test/forge/root/staking/CustomSupernetManager.t.sol
@@ -422,7 +422,9 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
         GenesisValidator memory account = genesisAccounts[0];
         assertEq(account.addr, bob, "should set validator address");
         assertEq(account.initialStake, 0, "should set initial stake");
-        assertEq(account.balance, amount, "should set balance");
+
+        uint256[] memory genesisBalances = supernetManager.genesisBalances();
+        assertEq(genesisBalances[0], amount, "should set balance");
     }
 
     function test_genesisSetFinalizedRevert() public {

--- a/test/forge/root/staking/CustomSupernetManager.t.sol
+++ b/test/forge/root/staking/CustomSupernetManager.t.sol
@@ -423,8 +423,8 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
         assertEq(account.addr, bob, "should set validator address");
         assertEq(account.initialStake, 0, "should set initial stake");
 
-        uint256[] memory genesisBalances = supernetManager.genesisBalances();
-        assertEq(genesisBalances[0], amount, "should set balance");
+        uint256 actualBalance = supernetManager.getGenesisBalance(account.addr);
+        assertEq(actualBalance, amount, "should set balance");
     }
 
     function test_addGenesisBalance_genesisSetFinalizedRevert() public {
@@ -432,6 +432,11 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
         supernetManager.enableStaking();
         vm.expectRevert("CustomSupernetManager: GENESIS_SET_IS_ALREADY_FINALIZED");
         supernetManager.addGenesisBalance(amount);
+    }
+
+     function test_addGenesisBalance_invalidAmountRevert() public {
+        vm.expectRevert("CustomSupernetManager: INVALID_AMOUNT");
+        supernetManager.addGenesisBalance(0);
     }
 }
 

--- a/test/forge/root/staking/CustomSupernetManager.t.sol
+++ b/test/forge/root/staking/CustomSupernetManager.t.sol
@@ -410,12 +410,12 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
         );
     }
 
-    function test_successfulPremine() public {
+    function test_addGenesisBalance_successful() public {
         vm.startPrank(bob);
         token.approve(address(supernetManager), amount);
         vm.expectEmit(true, true, true, true);
         emit AccountPremined(bob, amount);
-        supernetManager.premine(amount);
+        supernetManager.addGenesisBalance(amount);
 
         GenesisValidator[] memory genesisAccounts = supernetManager.genesisSet();
         assertEq(genesisAccounts.length, 1, "should set genesisSet");
@@ -427,11 +427,11 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
         assertEq(genesisBalances[0], amount, "should set balance");
     }
 
-    function test_genesisSetFinalizedRevert() public {
+    function test_addGenesisBalance_genesisSetFinalizedRevert() public {
         supernetManager.finalizeGenesis();
         supernetManager.enableStaking();
         vm.expectRevert("CustomSupernetManager: GENESIS_SET_IS_ALREADY_FINALIZED");
-        supernetManager.premine(amount);
+        supernetManager.addGenesisBalance(amount);
     }
 }
 
@@ -450,19 +450,19 @@ contract CustomSupernetManager_UndefinedRootERC20Predicate is Uninitialized {
         );
     }
 
-    function test_revertUndefinedRootERC20Predicate() public {
+    function test_addGenesisBalance_revertUndefinedRootERC20Predicate() public {
         vm.expectRevert(
             abi.encodeWithSelector(Unauthorized.selector, "CustomSupernetManager: UNDEFINED_ROOT_ERC20_PREDICATE")
         );
-        supernetManager.premine(100 ether);
+        supernetManager.addGenesisBalance(100 ether);
     }
 }
 
 contract CustomSupernetManager_UndefinedNativeTokenRoot is Initialized {
-    function test_revertUndefinedNativeTokenRoot() public {
+    function test_addGenesisBalance_revertUndefinedNativeTokenRoot() public {
         vm.expectRevert(
             abi.encodeWithSelector(Unauthorized.selector, "CustomSupernetManager: UNDEFINED_NATIVE_TOKEN_ROOT")
         );
-        supernetManager.premine(100 ether);
+        supernetManager.addGenesisBalance(100 ether);
     }
 }

--- a/test/forge/root/staking/CustomSupernetManager.t.sol
+++ b/test/forge/root/staking/CustomSupernetManager.t.sol
@@ -8,6 +8,7 @@ import {ExitHelper} from "contracts/root/ExitHelper.sol";
 import {StakeManager} from "contracts/root/staking/StakeManager.sol";
 import {CustomSupernetManager, Validator, GenesisValidator} from "contracts/root/staking/CustomSupernetManager.sol";
 import {MockERC20} from "contracts/mocks/MockERC20.sol";
+import {RootERC20Predicate} from "contracts/root/RootERC20Predicate.sol";
 import "contracts/interfaces/Errors.sol";
 
 abstract contract Uninitialized is Test {
@@ -20,6 +21,7 @@ abstract contract Uninitialized is Test {
     MockERC20 token;
     StakeManager stakeManager;
     CustomSupernetManager supernetManager;
+    RootERC20Predicate rootERC20Predicate;
 
     function setUp() public virtual {
         bls = new BLS();
@@ -30,6 +32,7 @@ abstract contract Uninitialized is Test {
         stakeManager = new StakeManager();
         supernetManager = new CustomSupernetManager();
         stakeManager.initialize(address(token));
+        rootERC20Predicate = new RootERC20Predicate();
     }
 }
 
@@ -43,6 +46,7 @@ abstract contract Initialized is Uninitialized {
             address(token),
             childValidatorSet,
             exitHelper,
+            address(rootERC20Predicate),
             DOMAIN
         );
     }
@@ -170,6 +174,7 @@ contract CustomSupernetManager_Initialize is Uninitialized {
             address(token),
             childValidatorSet,
             exitHelper,
+            address(rootERC20Predicate),
             DOMAIN
         );
         assertEq(supernetManager.owner(), address(this), "should set owner");

--- a/test/forge/root/staking/CustomSupernetManager.t.sol
+++ b/test/forge/root/staking/CustomSupernetManager.t.sol
@@ -390,7 +390,7 @@ contract CustomSupernetManager_Unstake is EnabledStaking {
 
 contract CustomSupernetManager_PremineInitialized is Initialized {
     uint256 amount = 100 ether;
-    event AccountPremined(address indexed account, uint256 amount);
+    event GenesisBalanceAdded(address indexed account, uint256 indexed amount);
 
     address childERC20Predicate;
     address childTokenTemplate;
@@ -414,7 +414,7 @@ contract CustomSupernetManager_PremineInitialized is Initialized {
         vm.startPrank(bob);
         token.approve(address(supernetManager), amount);
         vm.expectEmit(true, true, true, true);
-        emit AccountPremined(bob, amount);
+        emit GenesisBalanceAdded(bob, amount);
         supernetManager.addGenesisBalance(amount);
 
         GenesisValidator[] memory genesisAccounts = supernetManager.genesisSet();

--- a/test/forge/root/staking/deployment/DeployCustomSupernetManager.t.sol
+++ b/test/forge/root/staking/deployment/DeployCustomSupernetManager.t.sol
@@ -25,6 +25,7 @@ contract DeployCustomSupernetManagerTest is Test {
     address newMatic;
     address newChildValidatorSet;
     address newExitHelper;
+    address newRootERC20Predicate;
     string newDomain;
 
     function setUp() public {
@@ -37,6 +38,7 @@ contract DeployCustomSupernetManagerTest is Test {
         newMatic = makeAddr("newMatic");
         newChildValidatorSet = makeAddr("newChildValidatorSet");
         newExitHelper = makeAddr("newExitHelper");
+        newRootERC20Predicate = makeAddr("newRootERC20Predicate");
         newDomain = "newDomain";
 
         (logicAddr, proxyAddr) = deployer.run(
@@ -47,6 +49,7 @@ contract DeployCustomSupernetManagerTest is Test {
             newMatic,
             newChildValidatorSet,
             newExitHelper,
+            newRootERC20Predicate,
             newDomain
         );
         _recordProxy(proxyAddr);
@@ -70,6 +73,7 @@ contract DeployCustomSupernetManagerTest is Test {
             newMatic,
             newChildValidatorSet,
             newExitHelper,
+            newRootERC20Predicate,
             newDomain
         );
 


### PR DESCRIPTION
This PR introduces `addGenesisBalance` function in `CustomSupernetManager`, which allows Supernets users who are using rootchain-originated token as native token to be able to make bridge transactions. It enables the genesis premine mechanism and is similar to what has been done for staking. Accounts that are about to be premined in the genesis time on the Supernets, need to lock their funds on root erc 20 predicate and then when Supernets is started from the genesis block, we are going to premine exactly the same amount of tokens, which prevents premining out of thin air.